### PR TITLE
✨ feat [#21-themepark-read] 테마파크 Read 기능 구현

### DIFF
--- a/themepark-service/src/main/java/com/business/themeparkservice/themepark/application/dto/response/ResThemeparkGetByIdDTOApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/themepark/application/dto/response/ResThemeparkGetByIdDTOApiV1.java
@@ -1,0 +1,71 @@
+package com.business.themeparkservice.themepark.application.dto.response;
+
+import com.business.themeparkservice.themepark.domain.vo.ThemeparkType;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResThemeparkGetByIdDTOApiV1 {
+    public static ResThemeparkGetByIdDTOApiV1 of(UUID id) {
+        return ResThemeparkGetByIdDTOApiV1.builder()
+                .themePark(ThemePark.from(id))
+                .build();
+    }
+
+    private ThemePark themePark;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    private static class ThemePark{
+        private UUID id;
+        private String name;
+        private String description;
+        private ThemeparkType type;
+
+        @JsonFormat(pattern = "HH:mm")
+        private LocalTime operationStartTime;
+
+        @JsonFormat(pattern = "HH:mm")
+        private LocalTime operationEndTime;
+
+        private String heightLimit;
+        private Boolean supervisor;
+        private Hashtag hashtag;
+
+        public static ThemePark from(UUID id){
+            Hashtag hashtag = new Hashtag();
+            hashtag.setName(List.of("name1","name2"));
+
+            return ThemePark.builder()
+                    .id(id)
+                    .name("놀이기구1")
+                    .description("슝슝 놀이기구입니다.")
+                    .type(ThemeparkType.valueOf("RIDE"))
+                    .operationStartTime(LocalTime.parse("10:00"))
+                    .operationEndTime(LocalTime.parse("18:00"))
+                    .heightLimit("130~180cm")
+                    .supervisor(true)
+                    .hashtag(hashtag)
+                    .build();
+        }
+
+        @Getter
+        @Setter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class Hashtag {
+            private List<String> name;
+        }
+
+    }
+}

--- a/themepark-service/src/main/java/com/business/themeparkservice/themepark/common/dto/ResDTO.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/themepark/common/dto/ResDTO.java
@@ -1,0 +1,12 @@
+package com.business.themeparkservice.themepark.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ResDTO<T> {
+    private Integer code;
+    private String message;
+    private T data;
+}

--- a/themepark-service/src/main/java/com/business/themeparkservice/themepark/presentation/controller/ThemeparkControllerApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/themepark/presentation/controller/ThemeparkControllerApiV1.java
@@ -34,7 +34,7 @@ public class ThemeparkControllerApiV1 {
         return new ResponseEntity<>(
                 ResDTO.<ResThemeparkGetByIdDTOApiV1>builder()
                         .code(0)
-                        .message("테마파크 생성을 성공했습니다.")
+                        .message("테마파크 조회에 성공했습니다.")
                         .data(ResThemeparkGetByIdDTOApiV1.of(id))
                         .build(),
                 HttpStatus.OK

--- a/themepark-service/src/main/java/com/business/themeparkservice/themepark/presentation/controller/ThemeparkControllerApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/themepark/presentation/controller/ThemeparkControllerApiV1.java
@@ -1,22 +1,43 @@
 package com.business.themeparkservice.themepark.presentation.controller;
 
 import com.business.themeparkservice.themepark.application.dto.request.ReqThemeparkPostDTOApiV1;
+import com.business.themeparkservice.themepark.application.dto.response.ResThemeparkGetByIdDTOApiV1;
 import com.business.themeparkservice.themepark.application.dto.response.ResThemeparkPostDTOApiv1;
+import com.business.themeparkservice.themepark.common.dto.ResDTO;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/v1/themeparks")
 public class ThemeparkControllerApiV1 {
 
     @PostMapping
-    public ResponseEntity<ResThemeparkPostDTOApiv1> postThemepark(
+    public ResponseEntity<ResDTO<ResThemeparkPostDTOApiv1>> postThemepark(
             @Valid @RequestBody ReqThemeparkPostDTOApiV1 reqDto){
 
-        return ResponseEntity.ok(ResThemeparkPostDTOApiv1.of(reqDto));
+        return new ResponseEntity<>(
+                ResDTO.<ResThemeparkPostDTOApiv1>builder()
+                        .code(0)
+                        .message("테마파크 생성을 성공했습니다.")
+                        .data(ResThemeparkPostDTOApiv1.of(reqDto))
+                        .build(),
+                HttpStatus.OK
+                );
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ResDTO<ResThemeparkGetByIdDTOApiV1>> getThemeparkById(@PathVariable UUID id){
+        return new ResponseEntity<>(
+                ResDTO.<ResThemeparkGetByIdDTOApiV1>builder()
+                        .code(0)
+                        .message("테마파크 생성을 성공했습니다.")
+                        .data(ResThemeparkGetByIdDTOApiV1.of(id))
+                        .build(),
+                HttpStatus.OK
+        );
     }
 }

--- a/themepark-service/src/test/java/com/business/themeparkservice/httpclient/themeparks.http
+++ b/themepark-service/src/test/java/com/business/themeparkservice/httpclient/themeparks.http
@@ -14,3 +14,7 @@ Content-Type: application/json
       "hashtag": ["f5e49e7d-3baf-478f-bb36-d70b66330f79", "f5e49e5d-3baf-478f-bb36-d70b66330f79"]
     }
 }
+
+###
+
+GET http://localhost:8080/v1/themeparks/f5e49e7d-3baf-478f-bb36-d70b66330f79


### PR DESCRIPTION
### 변경 타입
* [X] 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [X] 코드 작성 가이드라인을 준수했는가?
* [X] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- 공통응답 Dto 생성 및 Controller에 추가
- Read ResponseDto 구현
- Test code 추가

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

- 입력코드
<img width="610" alt="스크린샷 2025-04-08 오전 11 00 58" src="https://github.com/user-attachments/assets/7441fb0c-2074-41b7-987e-28e4cd56a209" />

--------

- 결과
<img width="610" alt="스크린샷 2025-04-08 오전 11 03 31" src="https://github.com/user-attachments/assets/52885145-d0fb-4ccd-bd72-4063002f1cf5" />


