### PR TITLE
✨ feat[#22-hashtag-create] 해시태그 Create 기능 구현

### DIFF
--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
         - id: themepark-service
           uri: lb://themepark-service
           predicates:
-            - Path=/v1/themeparks/**
+            - Path=/v1/themeparks/**,/v1/hashtags/**
 
         - id: user-service
           uri: lb://user-service

--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -1,5 +1,10 @@
 dependencies {
 	//eureka client
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+	//jakarta
+	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 }
 

--- a/order-service/src/main/java/com/sparta/orderservice/application/dto/request/ReqOrderPutDtoApiV1.java
+++ b/order-service/src/main/java/com/sparta/orderservice/application/dto/request/ReqOrderPutDtoApiV1.java
@@ -1,0 +1,36 @@
+package com.sparta.orderservice.application.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReqOrderPutDtoApiV1 {
+
+    @Valid
+    @NotNull(message = "주문 정보를 입력해주세요.")
+    private Order order;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Order {
+
+        @NotBlank(message = "슬랙 ID를 입력해주세요.")
+        private String slackId;
+
+        @NotBlank(message = "주문상태를 입력해주세요.")
+        private String orderStatus;
+    }
+
+}
+
+

--- a/order-service/src/main/java/com/sparta/orderservice/application/dto/request/ReqOrdersPostDtoApiV1.java
+++ b/order-service/src/main/java/com/sparta/orderservice/application/dto/request/ReqOrdersPostDtoApiV1.java
@@ -24,7 +24,8 @@ public class ReqOrdersPostDtoApiV1 {
         private String slackId;
 
         @NotBlank(message = "주문제품의 수량을 입력해주세요.")
-        private int orderQuantity;
+        private Integer orderQuantity;
+
 
         @NotBlank(message = "상품의 정보를 입력해주세요.")
         private UUID product_id;

--- a/order-service/src/main/java/com/sparta/orderservice/presentation/controller/OrderControllerApiV1.java
+++ b/order-service/src/main/java/com/sparta/orderservice/presentation/controller/OrderControllerApiV1.java
@@ -1,15 +1,15 @@
 package com.sparta.orderservice.presentation.controller;
 
+import com.sparta.orderservice.application.dto.request.ReqOrderPutDtoApiV1;
 import com.sparta.orderservice.application.dto.request.ReqOrdersPostDtoApiV1;
 import com.sparta.orderservice.application.dto.response.ResDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.http.HttpStatus;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("v1/orders")
@@ -19,7 +19,7 @@ public class OrderControllerApiV1 {
     @PostMapping
     public ResponseEntity<ResDto<Object>> createOrder(
             @Valid @RequestBody ReqOrdersPostDtoApiV1 reqOrdersPostDtoApiV1) {
-        System.out.println(reqOrdersPostDtoApiV1.toString());
+
         return new ResponseEntity<>(
                 ResDto.builder()
                         .code(0) //Ok 코드
@@ -29,4 +29,18 @@ public class OrderControllerApiV1 {
         );
     }
 
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ResDto<Object>> updateOrder(
+            @PathVariable("id") @UUID String id,
+            @RequestBody ReqOrderPutDtoApiV1 reqOrderPutDtoApiV1) {
+        return new ResponseEntity<>(
+            ResDto.builder()
+                    .code(0) //Ok 코드
+                    .message("상품을 수정하였습니다!")
+                    .build(),
+            HttpStatus.OK
+        );
+    }
 }
+

--- a/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/dto/request/ReqHashtagPostDTOApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/dto/request/ReqHashtagPostDTOApiV1.java
@@ -1,5 +1,8 @@
 package com.business.themeparkservice.hashtag.application.dto.request;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +13,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReqHashtagPostDTOApiV1 {
-
+    @Valid
+    @NotNull(message = "해시태그 정보를 입력해주세요")
     private Hashtag hashtag;
 
     @Getter
@@ -18,6 +22,7 @@ public class ReqHashtagPostDTOApiV1 {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Hashtag{
+        @NotBlank(message = "해시태그 이름을 입력해주세요")
         private String name;
     }
 }

--- a/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/dto/request/ReqHashtagPostDTOApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/dto/request/ReqHashtagPostDTOApiV1.java
@@ -1,0 +1,23 @@
+package com.business.themeparkservice.hashtag.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReqHashtagPostDTOApiV1 {
+
+    private Hashtag hashtag;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Hashtag{
+        private String name;
+    }
+}

--- a/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/dto/response/ResHashtagPostDTOApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/dto/response/ResHashtagPostDTOApiV1.java
@@ -31,7 +31,7 @@ public class ResHashtagPostDTOApiV1 {
 
         public static Hashtag from(ReqHashtagPostDTOApiV1 reqDto) {
             return Hashtag.builder()
-                    .id(UUID.fromString("a6e49e7h-1eaf-478f-bb36-d73b66330f79"))
+                    .id(UUID.fromString("f5e49e7d-3baf-478f-bb36-d73b66330f79"))
                     .name(reqDto.getHashtag().getName())
                     .build();
         }

--- a/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/dto/response/ResHashtagPostDTOApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/dto/response/ResHashtagPostDTOApiV1.java
@@ -1,0 +1,40 @@
+package com.business.themeparkservice.hashtag.application.dto.response;
+
+import com.business.themeparkservice.hashtag.application.dto.request.ReqHashtagPostDTOApiV1;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResHashtagPostDTOApiV1 {
+
+    private Hashtag hashtag;
+
+    public static ResHashtagPostDTOApiV1 of(ReqHashtagPostDTOApiV1 reqDto) {
+        return ResHashtagPostDTOApiV1.builder()
+                .hashtag(Hashtag.from(reqDto))
+                .build();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Hashtag{
+        private UUID id;
+        private String name;
+
+        public static Hashtag from(ReqHashtagPostDTOApiV1 reqDto) {
+            return Hashtag.builder()
+                    .id(UUID.fromString("a6e49e7h-1eaf-478f-bb36-d73b66330f79"))
+                    .name(reqDto.getHashtag().getName())
+                    .build();
+        }
+
+    }
+}

--- a/themepark-service/src/main/java/com/business/themeparkservice/hashtag/common/dto/ResDTO.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/hashtag/common/dto/ResDTO.java
@@ -1,0 +1,12 @@
+package com.business.themeparkservice.hashtag.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ResDTO<T> {
+    private Integer code;
+    private String message;
+    private T data;
+}

--- a/themepark-service/src/main/java/com/business/themeparkservice/hashtag/presentation/controller/HashtagControllerApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/hashtag/presentation/controller/HashtagControllerApiV1.java
@@ -3,6 +3,7 @@ package com.business.themeparkservice.hashtag.presentation.controller;
 import com.business.themeparkservice.hashtag.application.dto.request.ReqHashtagPostDTOApiV1;
 import com.business.themeparkservice.hashtag.application.dto.response.ResHashtagPostDTOApiV1;
 import com.business.themeparkservice.themepark.common.dto.ResDTO;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class HashtagControllerApiV1 {
 
     @PostMapping
-    public ResponseEntity<ResDTO<ResHashtagPostDTOApiV1>> postHashtag(@RequestBody ReqHashtagPostDTOApiV1 reqDto){
+    public ResponseEntity<ResDTO<ResHashtagPostDTOApiV1>> postHashtag(@Valid @RequestBody ReqHashtagPostDTOApiV1 reqDto){
         return new ResponseEntity<>(
                 ResDTO.<ResHashtagPostDTOApiV1>builder()
                         .code(0)

--- a/themepark-service/src/main/java/com/business/themeparkservice/hashtag/presentation/controller/HashtagControllerApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/hashtag/presentation/controller/HashtagControllerApiV1.java
@@ -1,0 +1,28 @@
+package com.business.themeparkservice.hashtag.presentation.controller;
+
+import com.business.themeparkservice.hashtag.application.dto.request.ReqHashtagPostDTOApiV1;
+import com.business.themeparkservice.hashtag.application.dto.response.ResHashtagPostDTOApiV1;
+import com.business.themeparkservice.themepark.common.dto.ResDTO;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/hashtags")
+public class HashtagControllerApiV1 {
+
+    @PostMapping
+    public ResponseEntity<ResDTO<ResHashtagPostDTOApiV1>> postHashtag(@RequestBody ReqHashtagPostDTOApiV1 reqDto){
+        return new ResponseEntity<>(
+                ResDTO.<ResHashtagPostDTOApiV1>builder()
+                        .code(0)
+                        .message("해시태그 생성을 성공했습니다.")
+                        .data(ResHashtagPostDTOApiV1.of(reqDto))
+                        .build(),
+                HttpStatus.CREATED
+        );
+    }
+}

--- a/themepark-service/src/test/java/com/business/themeparkservice/httpclient/hashtags.http
+++ b/themepark-service/src/test/java/com/business/themeparkservice/httpclient/hashtags.http
@@ -1,0 +1,6 @@
+POST http://localhost:8080/v1/hashtags
+Content-Type: application/json
+
+{
+  "name": "신나는"
+}

--- a/themepark-service/src/test/java/com/business/themeparkservice/httpclient/hashtags.http
+++ b/themepark-service/src/test/java/com/business/themeparkservice/httpclient/hashtags.http
@@ -2,5 +2,7 @@ POST http://localhost:8080/v1/hashtags
 Content-Type: application/json
 
 {
-  "name": "신나는"
+  "hashtag": {
+    "name": "신나는"
+  }
 }

--- a/user-service/src/main/java/com/business/userservice/application/dto/request/ReqUserPutDTOApiV1.java
+++ b/user-service/src/main/java/com/business/userservice/application/dto/request/ReqUserPutDTOApiV1.java
@@ -1,0 +1,22 @@
+package com.business.userservice.application.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@Builder
+public class ReqUserPutDTOApiV1 {
+
+    @JsonProperty
+    private User user;
+
+    @Builder
+    public static class User {
+        private String username;
+        private String password;
+        private String slackId;
+
+//        public void update(UserEntity userEntity) {
+//            userEntity.update(username, password, slackId);
+//        }
+    }
+}

--- a/user-service/src/main/java/com/business/userservice/presentation/controller/UserControllerApiV1.java
+++ b/user-service/src/main/java/com/business/userservice/presentation/controller/UserControllerApiV1.java
@@ -1,0 +1,31 @@
+package com.business.userservice.presentation.controller;
+
+import com.business.userservice.application.dto.request.ReqUserPutDTOApiV1;
+import com.business.userservice.common.dto.ResDTO;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/users")
+public class UserControllerApiV1 {
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ResDTO<Object>> putBy(
+        @PathVariable Long id,
+        @Valid @RequestBody ReqUserPutDTOApiV1 dto
+    ) {
+        return new ResponseEntity<>(
+            ResDTO.builder()
+                .code(0)
+                .message("회원 정보 수정에 성공했습니다.")
+                .build(),
+            HttpStatus.OK
+        );
+    }
+}


### PR DESCRIPTION
### 변경 타입
* [X] 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [X] 코드 작성 가이드라인을 준수했는가?
* [X] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- 해시태그 controller 작성
- create api 코드작성
- create api 관련 request,respone dto 작성
- create api 테스트 코드 작성

- gateway hashtag 엔드포인트 추가

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

-작성코드&결과

<img width="742" alt="스크린샷 2025-04-08 오후 2 41 26" src="https://github.com/user-attachments/assets/43c84c3e-9782-42f0-998c-6feb068a0225" />
