### PR TITLE
✨ feat [#22-hashtag-search] 테마파크해시태그 Search 기능 구현

### DIFF
--- a/themepark-service/build.gradle
+++ b/themepark-service/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    runtimeOnly 'com.h2database:h2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 }

--- a/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/dto/response/ResHashtagGetDTOApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/dto/response/ResHashtagGetDTOApiV1.java
@@ -1,0 +1,68 @@
+package com.business.themeparkservice.hashtag.application.dto.response;
+
+import com.business.themeparkservice.hashtag.domain.entity.HashtagEntity;
+import lombok.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.web.PagedModel;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResHashtagGetDTOApiV1 {
+
+    private HashtagPage hashtagPage;
+
+    public static ResHashtagGetDTOApiV1 of(Page<HashtagEntity> tempHashtagPage) {
+        return ResHashtagGetDTOApiV1.builder()
+                .hashtagPage(new HashtagPage(tempHashtagPage))
+                .build();
+    }
+
+    @Getter
+    @ToString
+    public static class HashtagPage extends PagedModel<HashtagPage.Hashtag> {
+        public HashtagPage(Page<HashtagEntity> hashtagEntityPage) {
+            super(
+                    new PageImpl<>(
+                            Hashtag.from(hashtagEntityPage.getContent()),
+                            hashtagEntityPage.getPageable(),
+                            hashtagEntityPage.getTotalElements()
+
+                    )
+            );
+        }
+
+        @Getter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class Hashtag {
+            private UUID id;
+            private String name;
+
+            public static List<Hashtag> from(List<HashtagEntity> hashtagEntityList) {
+                return hashtagEntityList.stream()
+                        .map(Hashtag::from)
+                        .toList();
+            }
+
+            public static Hashtag from(HashtagEntity entity) {
+                return Hashtag.builder()
+                        .id(UUID.fromString("f5e49e5d-3baf-478f-bb36-d70b66330f79"))
+                        .name("신나는")
+                        .build();
+            }
+
+        }
+
+
+
+
+
+    }
+}

--- a/themepark-service/src/main/java/com/business/themeparkservice/hashtag/domain/entity/HashtagEntity.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/hashtag/domain/entity/HashtagEntity.java
@@ -1,0 +1,4 @@
+package com.business.themeparkservice.hashtag.domain.entity;
+
+public class HashtagEntity {
+}

--- a/themepark-service/src/main/java/com/business/themeparkservice/hashtag/presentation/controller/HashtagControllerApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/hashtag/presentation/controller/HashtagControllerApiV1.java
@@ -3,14 +3,21 @@ package com.business.themeparkservice.hashtag.presentation.controller;
 import com.business.themeparkservice.hashtag.application.dto.request.ReqHashtagPostDTOApiV1;
 import com.business.themeparkservice.hashtag.application.dto.request.ReqHashtagPutDTOApiV1;
 import com.business.themeparkservice.hashtag.application.dto.response.ResHashtagGetByIdDTOApiV1;
+import com.business.themeparkservice.hashtag.application.dto.response.ResHashtagGetDTOApiV1;
 import com.business.themeparkservice.hashtag.application.dto.response.ResHashtagPostDTOApiV1;
 import com.business.themeparkservice.hashtag.application.dto.response.ResHashtagPutDTOApiV1;
+import com.business.themeparkservice.hashtag.domain.entity.HashtagEntity;
 import com.business.themeparkservice.themepark.common.dto.ResDTO;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -39,6 +46,31 @@ public class HashtagControllerApiV1 {
                         .build(),
                 HttpStatus.OK
         );
+    }
+
+    @GetMapping
+    public ResponseEntity<ResDTO<ResHashtagGetDTOApiV1>> getHashtag(
+            @RequestParam(required = false) String name,
+            @PageableDefault(page = 0, size = 10, sort = "createdAt") Pageable pageable
+    ){
+        List<HashtagEntity> tempHashtags = List.of(
+                new HashtagEntity(),
+                new HashtagEntity()
+        );
+
+        Page<HashtagEntity> tempHashtagPage = new PageImpl<>(
+                tempHashtags, pageable, tempHashtags.size()
+        );
+
+        return new ResponseEntity<>(
+                ResDTO.<ResHashtagGetDTOApiV1>builder()
+                        .code(0)
+                        .message("해시태그 검색에 성공했습니다.")
+                        .data(ResHashtagGetDTOApiV1.of(tempHashtagPage))
+                        .build(),
+                HttpStatus.OK
+        );
+
     }
 
     @PutMapping("/{id}")

--- a/themepark-service/src/main/java/com/business/themeparkservice/themepark/application/dto/response/ResThemeparkGetDTOApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/themepark/application/dto/response/ResThemeparkGetDTOApiV1.java
@@ -1,0 +1,99 @@
+package com.business.themeparkservice.themepark.application.dto.response;
+
+import com.business.themeparkservice.themepark.domain.entity.ThemeparkEntity;
+import com.business.themeparkservice.themepark.domain.vo.ThemeparkType;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.web.PagedModel;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResThemeparkGetDTOApiV1 {
+
+    private ThemeparkPage themeparkPage;
+
+    public static ResThemeparkGetDTOApiV1 of(Page<ThemeparkEntity> themeparkEntityPage){
+        return ResThemeparkGetDTOApiV1.builder()
+                .themeparkPage(new ThemeparkPage(themeparkEntityPage))
+                .build();
+    }
+
+    @Getter
+    @ToString
+    public static class ThemeparkPage extends PagedModel<ThemeparkPage.Themepark> {
+        public ThemeparkPage(Page<ThemeparkEntity> themeparkEntityPage) {
+            super(
+                    new PageImpl<>(
+                            Themepark.from(themeparkEntityPage.getContent()),
+                            themeparkEntityPage.getPageable(),
+                            themeparkEntityPage.getTotalElements()
+                    )
+            );
+        }
+
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        @NoArgsConstructor
+        public static class Themepark{
+            private UUID id;
+            private String name;
+            private String description;
+            private ThemeparkType type;
+
+            @JsonFormat(pattern = "HH:mm")
+            private LocalTime operationStartTime;
+
+            @JsonFormat(pattern = "HH:mm")
+            private LocalTime operationEndTime;
+
+            private String heightLimit;
+            private Boolean supervisor;
+            private Hashtag hashtag;
+
+            public static List<Themepark> from(List<ThemeparkEntity> themeparkEntityList) {
+                return themeparkEntityList.stream()
+                        .map(Themepark::from)
+                        .toList();
+            }
+
+            public static Themepark from(ThemeparkEntity entity) {
+                Hashtag hashtag = new Hashtag();
+                hashtag.setName(List.of("name1","name2"));
+
+                return Themepark.builder()
+                        .id(UUID.fromString("f5e49e7d-3baf-478f-bb36-d73b66330f79"))
+                        .name("놀이기구1")
+                        .description("슝슝 놀이기구입니다.")
+                        .type(ThemeparkType.valueOf("RIDE"))
+                        .operationStartTime(LocalTime.parse("10:00"))
+                        .operationEndTime(LocalTime.parse("18:00"))
+                        .heightLimit("130~180cm")
+                        .supervisor(true)
+                        .hashtag(hashtag)
+                        .build();
+            }
+
+
+            @Getter
+            @Setter
+            @Builder
+            @NoArgsConstructor
+            @AllArgsConstructor
+            public static class Hashtag {
+                private List<String> name;
+            }
+        }
+
+    }
+
+
+}

--- a/themepark-service/src/main/java/com/business/themeparkservice/themepark/domain/entity/ThemeparkEntity.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/themepark/domain/entity/ThemeparkEntity.java
@@ -1,0 +1,4 @@
+package com.business.themeparkservice.themepark.domain.entity;
+
+public class ThemeparkEntity {
+}

--- a/themepark-service/src/main/java/com/business/themeparkservice/themepark/presentation/controller/ThemeparkControllerApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/themepark/presentation/controller/ThemeparkControllerApiV1.java
@@ -3,14 +3,21 @@ package com.business.themeparkservice.themepark.presentation.controller;
 import com.business.themeparkservice.themepark.application.dto.request.ReqThemeparkPostDTOApiV1;
 import com.business.themeparkservice.themepark.application.dto.request.ReqThemeparkPutDTOApiV1;
 import com.business.themeparkservice.themepark.application.dto.response.ResThemeparkGetByIdDTOApiV1;
+import com.business.themeparkservice.themepark.application.dto.response.ResThemeparkGetDTOApiV1;
 import com.business.themeparkservice.themepark.application.dto.response.ResThemeparkPostDTOApiv1;
 import com.business.themeparkservice.themepark.application.dto.response.ResThemeparkPutDTOApiV1;
 import com.business.themeparkservice.themepark.common.dto.ResDTO;
+import com.business.themeparkservice.themepark.domain.entity.ThemeparkEntity;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -41,6 +48,31 @@ public class ThemeparkControllerApiV1 {
                         .build(),
                 HttpStatus.OK
         );
+    }
+
+    @GetMapping
+    public ResponseEntity<ResDTO<ResThemeparkGetDTOApiV1>>getThemepark(
+            @RequestParam(required = false) String searchValue,
+            @PageableDefault(page = 0, size = 10, sort = "createdAt") Pageable pageable
+    ){
+        List<ThemeparkEntity> tempThemeparks = List.of(
+                new ThemeparkEntity(),
+                new ThemeparkEntity()
+        );
+
+        Page<ThemeparkEntity> tempThemeparkPage = new PageImpl<>(
+                tempThemeparks, pageable, tempThemeparks.size()
+        );
+
+        return new ResponseEntity<>(
+                ResDTO.<ResThemeparkGetDTOApiV1>builder()
+                        .code(0)
+                        .message("테마파크 검색에 성공했습니다.")
+                        .data(ResThemeparkGetDTOApiV1.of(tempThemeparkPage))
+                        .build(),
+                HttpStatus.OK
+        );
+
     }
 
     @PutMapping("/{id}")

--- a/themepark-service/src/test/java/com/business/themeparkservice/httpclient/hashtags.http
+++ b/themepark-service/src/test/java/com/business/themeparkservice/httpclient/hashtags.http
@@ -13,6 +13,10 @@ GET http://localhost:8080/v1/hashtags/f5e49e7d-3baf-478f-bb36-d70b66330f79
 
 ###
 
+GET http://localhost:8080/v1/hashtags
+
+###
+
 PUT http://localhost:8080/v1/hashtags/f5e49e7d-3baf-478f-bb36-d70b66330f79
 Content-Type: application/json
 

--- a/themepark-service/src/test/java/com/business/themeparkservice/httpclient/themeparks.http
+++ b/themepark-service/src/test/java/com/business/themeparkservice/httpclient/themeparks.http
@@ -21,6 +21,10 @@ GET http://localhost:8080/v1/themeparks/f5e49e7d-3baf-478f-bb36-d70b66330f79
 
 ###
 
+GET http://localhost:8080/v1/themeparks
+
+###
+
 PUT http://localhost:8080/v1/themeparks/f5e49e7d-3baf-478f-bb36-d70b66330f79
 Content-Type: application/json
 


### PR DESCRIPTION
### 변경 타입
* [X] 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [X] 코드 작성 가이드라인을 준수했는가?
* [X] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- search api 구현
- search api 관련 resposneDto 생성
- HashtagEntity 생성
- 테스트 코드 작성

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
-엔드포인트

<img width="345" alt="스크린샷 2025-04-09 오전 11 32 58" src="https://github.com/user-attachments/assets/94340b8c-cb6c-4b4f-bb56-a958c70e067d" />

---

-결과

<img width="678" alt="스크린샷 2025-04-09 오전 11 32 37" src="https://github.com/user-attachments/assets/1511c044-849b-45c4-b6d8-56d7d59cc838" />


