### PR TITLE
📄 docs[#89-themepark] 테마파크 swagger 자동 문서화기능 추가

### DIFF
--- a/themepark-service/build.gradle
+++ b/themepark-service/build.gradle
@@ -1,8 +1,70 @@
+plugins {
+    id 'com.epages.restdocs-api-spec' version "0.19.2"
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'com.h2database:h2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.2'
+}
+
+
+// 컴파일 시 빌드 폴더를 지웁니다.
+compileJava {
+    dependsOn 'clean'
+}
+
+// OpenApi에 들어갈 메타데이터를 추가합니다.
+// 모놀리식일 경우 해당 프로젝트의 주소를 입력하고,
+// MSA일 경우 게이트웨이의 주소를 입력하면 됩니다.
+openapi3 {
+    servers = [
+            {
+                url = 'http://localhost:8080'
+            }
+    ]
+    title = 'THEMEPARK API'
+    description = ''
+    version = '1.0.0'
+    format = 'json'
+}
+
+// task를 만듭니다.
+tasks.register('setDocs') {
+    // openapi3 태스크를 먼저 실행합니다.
+    dependsOn 'openapi3'
+    // 문서가 다 생성되면 build 파일에 복사합니다.
+    // MSA일 경우 파일명이 중복될 수 있으므로,
+    // 파일명 뒤에 서비스명을 붙여줍시다.
+    doLast {
+        copy {
+            from "build/api-spec"
+            include "*.json"
+            include "*.yaml"
+            into "build/resources/main/static/springdoc"
+            rename { String fileName ->
+                if (fileName.endsWith('.json')) {
+                    return fileName.replace('.json', '-themepark-service.json')
+                } else if (fileName.endsWith('.yaml')) {
+                    return fileName.replace('.yaml', '-themepark-service.yml')
+                }
+                return fileName
+            }
+        }
+    }
+}
+
+// bootRun 실행 시 문서 생성 태스크를 실행합니다.
+bootRun {
+    dependsOn 'setDocs'
+}
+
+// bootJar 실행 시 문서 생성 태스크를 실행합니다.
+bootJar {
+    dependsOn 'setDocs'
 }

--- a/themepark-service/src/test/java/com/business/themeparkservice/hashtag/presentation/controller/HashtagControllerApiV1Test.java
+++ b/themepark-service/src/test/java/com/business/themeparkservice/hashtag/presentation/controller/HashtagControllerApiV1Test.java
@@ -2,12 +2,17 @@ package com.business.themeparkservice.hashtag.presentation.controller;
 
 import com.business.themeparkservice.hashtag.application.dto.request.ReqHashtagPostDTOApiV1;
 import com.business.themeparkservice.hashtag.application.dto.request.ReqHashtagPutDTOApiV1;
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -16,8 +21,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
 @SpringBootTest
 @AutoConfigureMockMvc
+@AutoConfigureRestDocs
 @Transactional
 @ActiveProfiles("dev")
 public class HashtagControllerApiV1Test {
@@ -39,32 +50,62 @@ public class HashtagControllerApiV1Test {
 
         String reqDtoJson = objectMapper.writeValueAsString(reqHashtagPostDTOApiV1);
         mockMvc.perform(
-                MockMvcRequestBuilders.post("/v1/hashtags")
+                RestDocumentationRequestBuilders.post("/v1/hashtags")
                         .content(reqDtoJson)
                         .contentType(MediaType.APPLICATION_JSON)
         )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isCreated()
+                ).andDo(
+                        MockMvcRestDocumentationWrapper.document("Hashtag 생성 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Hashtag v1")
+                                        .build()
+                                )
+                        )
                 );
     }
 
     @Test
     public void testThemeparkGetByIdSuccess() throws Exception{
         mockMvc.perform(
-                MockMvcRequestBuilders.get("/v1/hashtags/{id}", UUID.randomUUID())
+                RestDocumentationRequestBuilders.get("/v1/hashtags/{id}", UUID.randomUUID())
         )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isOk()
+                ).andDo(
+                        MockMvcRestDocumentationWrapper.document("Hashtag 단일 조회 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Hashtag v1")
+                                        .pathParameters(
+                                                parameterWithName("id").type(SimpleType.STRING).description("해시태그 ID")
+                                        )
+                                        .build()
+                                )
+                        )
                 );
     }
 
     @Test
     public void testThemeparkGetSuccess() throws Exception{
         mockMvc.perform(
-                        MockMvcRequestBuilders.get("/v1/hashtags")
-                )
+                RestDocumentationRequestBuilders.get("/v1/hashtags")
+        )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isOk()
+                ).andDo(
+                        MockMvcRestDocumentationWrapper.document("Hashtag 전체 조회 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Hashtag v1")
+                                        .build()
+                                )
+                        )
                 );
     }
 
@@ -80,22 +121,46 @@ public class HashtagControllerApiV1Test {
         String reqDtoJson = objectMapper.writeValueAsString(reqHashtagPutDTOApiV1);
 
         mockMvc.perform(
-                MockMvcRequestBuilders.put("/v1/hashtags/{id}", UUID.randomUUID())
+                RestDocumentationRequestBuilders.put("/v1/hashtags/{id}", UUID.randomUUID())
                         .content(reqDtoJson)
                         .contentType(MediaType.APPLICATION_JSON)
         )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isOk()
+                ).andDo(
+                        MockMvcRestDocumentationWrapper.document("Hashtag 수정 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Hashtag v1")
+                                        .pathParameters(
+                                                parameterWithName("id").type(SimpleType.STRING).description("해시태그 ID")
+                                        )
+                                        .build()
+                                )
+                        )
                 );
     }
 
     @Test
     public void testThemeparkDeleteSuccess() throws Exception{
         mockMvc.perform(
-                MockMvcRequestBuilders.delete("/v1/hashtags/{id}", UUID.randomUUID())
+                RestDocumentationRequestBuilders.delete("/v1/hashtags/{id}", UUID.randomUUID())
         )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isOk()
+                ).andDo(
+                        MockMvcRestDocumentationWrapper.document("Hashtag 삭제 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Hashtag v1")
+                                        .pathParameters(
+                                                parameterWithName("id").type(SimpleType.STRING).description("해시태그 ID")
+                                        )
+                                        .build()
+                                )
+                        )
                 );
     }
 }

--- a/themepark-service/src/test/java/com/business/themeparkservice/themepark/presentation/controller/ThemeparkControllerApiV1Test.java
+++ b/themepark-service/src/test/java/com/business/themeparkservice/themepark/presentation/controller/ThemeparkControllerApiV1Test.java
@@ -3,15 +3,19 @@ package com.business.themeparkservice.themepark.presentation.controller;
 import com.business.themeparkservice.themepark.application.dto.request.ReqThemeparkPostDTOApiV1;
 import com.business.themeparkservice.themepark.application.dto.request.ReqThemeparkPutDTOApiV1;
 import com.business.themeparkservice.themepark.domain.vo.ThemeparkType;
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,8 +24,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+
 @SpringBootTest
 @AutoConfigureMockMvc
+@AutoConfigureRestDocs
 @Transactional
 @ActiveProfiles("dev")
 public class ThemeparkControllerApiV1Test {
@@ -58,32 +66,65 @@ public class ThemeparkControllerApiV1Test {
         String reqDtoJson = objectMapper.writeValueAsString(reqThemeparkPostDTOApiV1);
 
         mockMvc.perform(
-                        MockMvcRequestBuilders.post("/v1/themeparks")
+                        RestDocumentationRequestBuilders.post("/v1/themeparks")
                                 .content(reqDtoJson)
                                 .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isCreated()
+                )
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("Themepark 생성 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Themepark v1")
+                                        .build()
+                                )
+                        )
                 );
     }
 
     @Test
     public void testThemeparkGetByIdSuccess() throws Exception{
         mockMvc.perform(
-                        MockMvcRequestBuilders.get("/v1/themeparks/{id}", UUID.randomUUID())
+                        RestDocumentationRequestBuilders.get("/v1/themeparks/{id}", UUID.randomUUID())
                 )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isOk()
+                )
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("Themepark 개별 조회 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Themepark v1")
+                                        .pathParameters(
+                                                parameterWithName("id").type(SimpleType.STRING).description("테마파크 ID")
+                                        )
+                                        .build()
+                                )
+                        )
                 );
     }
 
     @Test
     public void testThemeparkGetSuccess() throws Exception{
         mockMvc.perform(
-                        MockMvcRequestBuilders.get("/v1/themeparks")
+                        RestDocumentationRequestBuilders.get("/v1/themeparks")
                 )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isOk()
+                )
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("Themepark 전체 조회 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Themepark v1")
+                                        .build()
+                                )
+                        )
                 );
     }
 
@@ -112,22 +153,46 @@ public class ThemeparkControllerApiV1Test {
         String reqDtoJson = objectMapper.writeValueAsString(reqThemeparkPutDTOApiV1);
 
         mockMvc.perform(
-                    MockMvcRequestBuilders.put("/v1/themeparks/{id}", UUID.randomUUID())
+                        RestDocumentationRequestBuilders.put("/v1/themeparks/{id}", UUID.randomUUID())
                             .content(reqDtoJson)
                             .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isOk()
+                ).andDo(
+                        MockMvcRestDocumentationWrapper.document("Themepark 수정 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Themepark v1")
+                                        .pathParameters(
+                                                parameterWithName("id").type(SimpleType.STRING).description("테마파크 ID")
+                                        )
+                                        .build()
+                                )
+                        )
                 );
     }
 
     @Test
     public void testThemeparkDeleteSuccess() throws Exception{
         mockMvc.perform(
-                        MockMvcRequestBuilders.delete("/v1/themeparks/{id}", UUID.randomUUID())
+                        RestDocumentationRequestBuilders.delete("/v1/themeparks/{id}", UUID.randomUUID())
                 )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isOk()
+                ).andDo(
+                        MockMvcRestDocumentationWrapper.document("Themepark 삭제 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Themepark v1")
+                                        .pathParameters(
+                                                parameterWithName("id").type(SimpleType.STRING).description("테마파크 ID")
+                                        )
+                                        .build()
+                                )
+                        )
                 );
     }
 

--- a/themepark-service/src/test/java/com/business/themeparkservice/waiting/presentation/controller/WaitingControllerApiV1Test.java
+++ b/themepark-service/src/test/java/com/business/themeparkservice/waiting/presentation/controller/WaitingControllerApiV1Test.java
@@ -1,12 +1,17 @@
 package com.business.themeparkservice.waiting.presentation.controller;
 
 import com.business.themeparkservice.waiting.application.dto.request.ReqWaitingPostDTOApiV1;
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -15,8 +20,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
 @SpringBootTest
 @AutoConfigureMockMvc
+@AutoConfigureRestDocs
 @Transactional
 @ActiveProfiles("dev")
 public class WaitingControllerApiV1Test {
@@ -40,62 +51,128 @@ public class WaitingControllerApiV1Test {
         String reqJsonDto = objectMapper.writeValueAsString(reqWaitingPostDTOApiV1);
 
         mockMvc.perform(
-                MockMvcRequestBuilders.post("/v1/waitings")
+                RestDocumentationRequestBuilders.post("/v1/waitings")
                         .content(reqJsonDto)
                         .contentType(MediaType.APPLICATION_JSON)
         )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isCreated()
+                ).andDo(
+                        MockMvcRestDocumentationWrapper.document("Waiting 생성 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Waiting v1")
+                                        .build()
+                                )
+                        )
                 );
     }
 
     @Test
     public void testWaitingGetByIdSuccess() throws Exception{
         mockMvc.perform(
-                MockMvcRequestBuilders.get("/v1/waitings/{id}", UUID.randomUUID())
+                RestDocumentationRequestBuilders.get("/v1/waitings/{id}", UUID.randomUUID())
         )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isOk()
+                ).andDo(
+                        MockMvcRestDocumentationWrapper.document("Waiting 단일 조회 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Waiting v1")
+                                        .pathParameters(
+                                                parameterWithName("id").type(SimpleType.STRING).description("대기 ID")
+                                        )
+                                        .build()
+                                )
+                        )
                 );
     }
 
     @Test
     public void testWaitingGetSuccess() throws Exception{
         mockMvc.perform(
-                MockMvcRequestBuilders.get("/v1/waitings")
+                RestDocumentationRequestBuilders.get("/v1/waitings")
         )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isOk()
+                ).andDo(
+                        MockMvcRestDocumentationWrapper.document("Waiting 전체 조회 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Waiting v1")
+                                        .build()
+                                )
+                        )
                 );
     }
 
     @Test
     public void testWaitingPostDoneSuccess() throws Exception{
         mockMvc.perform(
-                MockMvcRequestBuilders.post("/v1/waitings/{id}", UUID.randomUUID()+"/done")
+                RestDocumentationRequestBuilders.post("/v1/waitings/{id}/done", UUID.randomUUID())
         )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isOk()
+                ).andDo(
+                        MockMvcRestDocumentationWrapper.document("Waiting 완료 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Waiting v1")
+                                        .pathParameters(
+                                                parameterWithName("id").type(SimpleType.STRING).description("대기 ID")
+                                        )
+                                        .build()
+                                )
+                        )
                 );
     }
 
     @Test
     public void testWaitingPostCancelSuccess() throws Exception{
         mockMvc.perform(
-                        MockMvcRequestBuilders.post("/v1/waitings/{id}", UUID.randomUUID()+"/cancel")
-                )
+                        RestDocumentationRequestBuilders.post("/v1/waitings/{id}/cancel", UUID.randomUUID())
+        )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isOk()
+                ).andDo(
+                        MockMvcRestDocumentationWrapper.document("Waiting 취소 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Waiting v1")
+                                        .pathParameters(
+                                                parameterWithName("id").type(SimpleType.STRING).description("대기 ID")
+                                        )
+                                        .build()
+                                )
+                        )
                 );
     }
 
     @Test
     public void testWaitingGetDeletedSuccess() throws Exception{
         mockMvc.perform(
-                MockMvcRequestBuilders.delete("/v1/waitings/{id}", UUID.randomUUID())
+                RestDocumentationRequestBuilders.delete("/v1/waitings/{id}", UUID.randomUUID())
         )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isOk()
+                ).andDo(
+                        MockMvcRestDocumentationWrapper.document("Waiting 삭제 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Waiting v1")
+                                        .pathParameters(
+                                                parameterWithName("id").type(SimpleType.STRING).description("대기 ID")
+                                        )
+                                        .build()
+                                )
+                        )
                 );
     }
 }


### PR DESCRIPTION
### 변경 타입
* [ ] 기능 추가/수정
* [ ] 버그 수정
* [X] 리팩토링
* [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [X] 문서작성

## 체크리스트

* [X] 코드 작성 가이드라인을 준수했는가?
* [X] 변경 사항에 대한 테스트를 완료했는가?
* [X] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- build.gradle 에 swagger 의존성 추가
- 테마파크 테스트코드 swagger 문서화 연결
- 해시태그 테스트코드 swagger 문서화 연결
- 대기 테스트코드 swagger 문서화 연결

*게이트웨이에 작성해야하는 swagger 경로는 병합오류를 고려하여 제외하고 올렸습니다!*

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

<img width="1460" alt="스크린샷 2025-04-10 오후 3 34 52" src="https://github.com/user-attachments/assets/548ada38-dabe-4662-846a-7ea457f86012" />
