### PR TITLE
✨ feat [#128-hashtag-delete] 해시태그 삭제 기능 구현

### DIFF
--- a/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/service/HashtagServiceApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/service/HashtagServiceApiV1.java
@@ -21,4 +21,6 @@ public interface HashtagServiceApiV1 {
     ResHashtagGetDTOApiV1 getBy(Predicate predicate, Pageable pageable);
 
     ResHashtagPutDTOApiV1 putBy(UUID id, ReqHashtagPutDTOApiV1 reqDto);
+
+    void deleteBy(UUID id);
 }

--- a/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/service/HashtagServiceImplApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/service/HashtagServiceImplApiV1.java
@@ -51,6 +51,11 @@ public class HashtagServiceImplApiV1 implements HashtagServiceApiV1{
         return ResHashtagPutDTOApiV1.of(hashtagEntity);
     }
 
+    @Override
+    public void deleteBy(UUID id) {
+        getHashtag(id).deletedBy(1L);
+    }
+
     private HashtagEntity getHashtag(UUID id) {
         return hashtagRepository.findById(id).orElseThrow(() -> new RuntimeException("Hashtag not found"));
     }

--- a/themepark-service/src/main/java/com/business/themeparkservice/hashtag/domain/entity/HashtagEntity.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/hashtag/domain/entity/HashtagEntity.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.Where;
 
 import java.util.List;
 import java.util.UUID;
@@ -13,6 +15,7 @@ import java.util.UUID;
 @Entity
 @Getter
 @Table(name = "p_hashtags")
+@SQLRestriction("deleted_at IS NULL")
 @NoArgsConstructor
 public class HashtagEntity extends BaseEntity {
     @Id
@@ -34,4 +37,5 @@ public class HashtagEntity extends BaseEntity {
     public void update(String name) {
         this.name = name;
     }
+
 }

--- a/themepark-service/src/main/java/com/business/themeparkservice/hashtag/presentation/controller/HashtagControllerApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/hashtag/presentation/controller/HashtagControllerApiV1.java
@@ -88,6 +88,7 @@ public class HashtagControllerApiV1 {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<ResDTO<Object>> deleteBy(@PathVariable UUID id){
+        hashtagService.deleteBy(id);
         return new ResponseEntity<>(
                 ResDTO.builder()
                         .code(0)

--- a/themepark-service/src/test/java/com/business/themeparkservice/httpclient/hashtags.http
+++ b/themepark-service/src/test/java/com/business/themeparkservice/httpclient/hashtags.http
@@ -9,7 +9,7 @@ Content-Type: application/json
 
 ####
 
-GET http://localhost:8080/v1/hashtags/f20d7a0c-0872-4b95-9440-dc2bd1c49cc1
+GET http://localhost:8080/v1/hashtags/1d57d230-3fe2-4b9b-ae80-d69f73a117b2
 
 ###
 
@@ -28,5 +28,5 @@ Content-Type: application/json
 
 ###
 
-DELETE http://localhost:8080/v1/hashtags/f5e49e7d-3baf-478f-bb36-d70b66330f78
+DELETE http://localhost:8080/v1/hashtags/1d57d230-3fe2-4b9b-ae80-d69f73a117b2
 


### PR DESCRIPTION
### 변경 타입
* [X] 기능 추가/수정
* [ ] 버그 수정
* [X] 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [X] 코드 작성 가이드라인을 준수했는가?
* [X] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- controller 수정
- service 로직추가
- soft delete 이후 삭제된 해시태그 조회 불가능하도록 구현
- 테스트코드 수정

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

- @SQLRestriction("deleted_at IS NULL") 
- 해당 어노테이션을 사용하여 삭제정보가 존재할 시 검색되지않도록 조건을 추가할수 있습니다.

<img width="509" alt="스크린샷 2025-04-14 오후 3 47 46" src="https://github.com/user-attachments/assets/2fbfb446-eeac-40fb-8161-52bd01de2fa6" />

<img width="852" alt="스크린샷 2025-04-14 오후 3 47 22" src="https://github.com/user-attachments/assets/fcf95659-7f1a-4a24-8351-5e944a6285fb" />

