### PR TITLE
✨ feat [#147-themepark-delete] 테마파크 삭제 기능 구현

### DIFF
--- a/themepark-service/src/main/java/com/business/themeparkservice/themepark/application/service/ThemeparkServiceApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/themepark/application/service/ThemeparkServiceApiV1.java
@@ -21,4 +21,6 @@ public interface ThemeparkServiceApiV1 {
     ResThemeparkGetDTOApiV1 getBy(Predicate predicate, Pageable pageable);
 
     ResThemeparkPutDTOApiV1 putBy(UUID id, ReqThemeparkPutDTOApiV1 reqDto);
+
+    void deleteBy(UUID id);
 }

--- a/themepark-service/src/main/java/com/business/themeparkservice/themepark/application/service/ThemeparkServiceImplApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/themepark/application/service/ThemeparkServiceImplApiV1.java
@@ -79,6 +79,13 @@ public class ThemeparkServiceImplApiV1 implements ThemeparkServiceApiV1 {
         return ResThemeparkPutDTOApiV1.of(themeparkEntity, hashtagNames);
     }
 
+    @Override
+    public void deleteBy(UUID id) {
+        ThemeparkEntity themeparkEntity = findThemepark(id);
+        themeparkEntity.deletedBy(1L);
+        themeparkEntity.getThemeparkHashtagEntityList().clear();
+    }
+
     private List<String> addHashtagNames(ThemeparkEntity themeparkEntity, ReqThemeparkPutDTOApiV1 reqDto) {
         List<ThemeparkHashtagEntity> themeparkHashtagEntityList = new ArrayList<>();
 

--- a/themepark-service/src/main/java/com/business/themeparkservice/themepark/domain/entity/ThemeparkEntity.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/themepark/domain/entity/ThemeparkEntity.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalTime;
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.UUID;
 @Entity
 @Getter
 @Table(name = "p_themeparks")
+@SQLRestriction("deleted_at IS NULL")
 @NoArgsConstructor
 @AllArgsConstructor
 public class ThemeparkEntity extends BaseEntity {

--- a/themepark-service/src/main/java/com/business/themeparkservice/themepark/domain/repository/ThemeparkHashtagRepository.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/themepark/domain/repository/ThemeparkHashtagRepository.java
@@ -9,4 +9,6 @@ import java.util.UUID;
 
 public interface ThemeparkHashtagRepository {
     List<ThemeparkHashtagEntity> findAllByThemeparkId(UUID id);
+
+    void deleteByThemepark_Id(UUID id);
 }

--- a/themepark-service/src/main/java/com/business/themeparkservice/themepark/presentation/controller/ThemeparkControllerApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/themepark/presentation/controller/ThemeparkControllerApiV1.java
@@ -92,6 +92,7 @@ public class ThemeparkControllerApiV1 {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<ResDTO<Object>> deleteBy(@PathVariable UUID id){
+        themeparkService.deleteBy(id);
         return new ResponseEntity<>(
                 ResDTO.builder()
                         .code(0)

--- a/themepark-service/src/test/java/com/business/themeparkservice/httpclient/themeparks.http
+++ b/themepark-service/src/test/java/com/business/themeparkservice/httpclient/themeparks.http
@@ -15,8 +15,8 @@ Content-Type: application/json
         "hashtagId": "b79fe1c3-3fb3-47e5-aa31-c7a8cb79a99a",
         "name": "신나는"
       },{
-        "hashtagId": "1d57d230-3fe2-4b9b-ae80-d69f73a117b2",
-        "name": "드라마틱"
+        "hashtagId": "f5e49e5d-3baf-478f-bb36-d70b66330f79",
+        "name": "짜릿한"
       }
       ]
     }
@@ -24,7 +24,7 @@ Content-Type: application/json
 
 ###
 
-GET http://localhost:8080/v1/themeparks/1ebb0dfa-1266-4736-a71b-4ee8b953a6b8
+GET http://localhost:8080/v1/themeparks/3dca02ed-55c7-4f7c-9e5b-2126f9b2139f
 
 ###
 
@@ -53,4 +53,4 @@ Content-Type: application/json
 
 ###
 
-DELETE http://localhost:8080/v1/themeparks/f5e49e7d-3baf-478f-bb36-d70b66330f79
+DELETE http://localhost:8080/v1/themeparks/1bce86d2-1afb-4e80-994e-a1fb4d92aaf9


### PR DESCRIPTION
### 변경 타입
* [X] 기능 추가/수정
* [ ] 버그 수정
* [X] 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [X] 코드 작성 가이드라인을 준수했는가?
* [X] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- controller 수정
- service 로직 연결
- 테마파크 삭제 시 중간테이블 정보도 삭제되도록 구현
- 테스트코드 수정

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

<img width="690" alt="스크린샷 2025-04-15 오후 1 04 41" src="https://github.com/user-attachments/assets/2f4c9c12-86f8-4672-acef-8b55f724cc60" />

