### PR TITLE
✨ feat [#142-product-search] 상품 다중 검색 기능 구현

### DIFF
--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.2'
 
     //common
-    implementation 'com.github.numberOnethemepark:common:0.0.6'
+    implementation 'com.github.numberOnethemepark:common:0.0.7'
 
     //querydsl
     implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"

--- a/product-service/src/main/java/com/business/productservice/application/dto/response/ResProductGetDTOApiV1.java
+++ b/product-service/src/main/java/com/business/productservice/application/dto/response/ResProductGetDTOApiV1.java
@@ -62,15 +62,15 @@ public class ResProductGetDTOApiV1 {
             }
             public static Product from(ProductEntity entity) {
                 return Product.builder()
-                        .id(UUID.fromString("0d47686e-c73c-4d70-80ae-ef51ea4bfed3"))
-                        .name("20% 할인 이벤트")
-                        .description("설명입니다.")
-                        .productType(ProductType.EVENT)
-                        .price(30000)
-                        .limitQuantity(100)
-                        .eventStartAt(LocalDateTime.now())
-                        .eventEndAt(LocalDateTime.now())
-                        .productStatus(ProductStatus.OPEN)
+                        .id(entity.getId())
+                        .name(entity.getName())
+                        .description(entity.getDescription())
+                        .productType(entity.getProductType())
+                        .price(entity.getPrice())
+                        .limitQuantity(entity.getLimitQuantity())
+                        .eventStartAt(entity.getEventStartAt())
+                        .eventEndAt(entity.getEventEndAt())
+                        .productStatus(entity.getProductStatus())
                         .build();
             }
 

--- a/product-service/src/main/java/com/business/productservice/application/service/ProductServiceApiV1.java
+++ b/product-service/src/main/java/com/business/productservice/application/service/ProductServiceApiV1.java
@@ -3,9 +3,12 @@ package com.business.productservice.application.service;
 import com.business.productservice.application.dto.request.ReqProductPostDTOApiV1;
 import com.business.productservice.application.dto.request.ReqProductPutDTOApiV1;
 import com.business.productservice.application.dto.response.ResProductGetByIdDTOApiV1;
+import com.business.productservice.application.dto.response.ResProductGetDTOApiV1;
 import com.business.productservice.application.dto.response.ResProductPostDTOApiV1;
 import com.business.productservice.application.dto.response.ResProductPutDTOApiV1;
+import com.querydsl.core.types.Predicate;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
 
 import java.util.UUID;
 
@@ -13,6 +16,8 @@ public interface ProductServiceApiV1 {
     ResProductPostDTOApiV1 postBy(@Valid ReqProductPostDTOApiV1 reqDto);
 
     ResProductGetByIdDTOApiV1 getBy(UUID id);
+
+    ResProductGetDTOApiV1 getBy(Predicate predicate, Pageable pageable);
 
     ResProductPutDTOApiV1 putBy(UUID id, ReqProductPutDTOApiV1 dto);
 

--- a/product-service/src/main/java/com/business/productservice/application/service/ProductServiceImplApiV1.java
+++ b/product-service/src/main/java/com/business/productservice/application/service/ProductServiceImplApiV1.java
@@ -3,6 +3,7 @@ package com.business.productservice.application.service;
 import com.business.productservice.application.dto.request.ReqProductPostDTOApiV1;
 import com.business.productservice.application.dto.request.ReqProductPutDTOApiV1;
 import com.business.productservice.application.dto.response.ResProductGetByIdDTOApiV1;
+import com.business.productservice.application.dto.response.ResProductGetDTOApiV1;
 import com.business.productservice.application.dto.response.ResProductPostDTOApiV1;
 import com.business.productservice.application.dto.response.ResProductPutDTOApiV1;
 import com.business.productservice.application.exception.ProductExceptionCode;
@@ -11,8 +12,11 @@ import com.business.productservice.domain.product.entity.StockEntity;
 import com.business.productservice.infrastructure.persistence.product.ProductJpaRepository;
 import com.business.productservice.infrastructure.persistence.product.StockJpaRepository;
 import com.github.themepark.common.application.exception.CustomException;
+import com.querydsl.core.types.Predicate;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -39,6 +43,13 @@ public class ProductServiceImplApiV1 implements ProductServiceApiV1{
         ProductEntity productEntity = productRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ProductExceptionCode.PRODUCT_NOT_FOUND));
         return ResProductGetByIdDTOApiV1.of(productEntity);
+    }
+
+    @Override
+    public ResProductGetDTOApiV1 getBy(Predicate predicate, Pageable pageable){
+
+        Page<ProductEntity> productEntityPage = productRepository.findAll(predicate, pageable);
+        return ResProductGetDTOApiV1.of(productEntityPage);
     }
 
     @Override

--- a/product-service/src/main/java/com/business/productservice/domain/product/repository/ProductRepository.java
+++ b/product-service/src/main/java/com/business/productservice/domain/product/repository/ProductRepository.java
@@ -1,4 +1,10 @@
 package com.business.productservice.domain.product.repository;
 
+import com.business.productservice.domain.product.entity.ProductEntity;
+import com.querydsl.core.types.Predicate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface ProductRepository {
+    Page<ProductEntity> findAll(Predicate predicate, Pageable pageable);
 }

--- a/product-service/src/main/java/com/business/productservice/infrastructure/persistence/product/ProductJpaRepository.java
+++ b/product-service/src/main/java/com/business/productservice/infrastructure/persistence/product/ProductJpaRepository.java
@@ -3,10 +3,11 @@ package com.business.productservice.infrastructure.persistence.product;
 import com.business.productservice.domain.product.entity.ProductEntity;
 import com.business.productservice.domain.product.repository.ProductRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
 
 @Repository
-public interface ProductJpaRepository extends JpaRepository<ProductEntity, UUID>, ProductRepository {
+public interface ProductJpaRepository extends JpaRepository<ProductEntity, UUID>, ProductRepository, QuerydslPredicateExecutor<ProductEntity> {
 }

--- a/product-service/src/main/java/com/business/productservice/presentation/controller/ProductControllerApiV1.java
+++ b/product-service/src/main/java/com/business/productservice/presentation/controller/ProductControllerApiV1.java
@@ -8,12 +8,13 @@ import com.business.productservice.application.dto.response.*;
 import com.business.productservice.application.service.ProductServiceApiV1;
 import com.business.productservice.domain.product.entity.ProductEntity;
 import com.github.themepark.common.application.dto.ResDTO;
+import com.querydsl.core.types.Predicate;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.querydsl.binding.QuerydslPredicate;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -64,24 +65,16 @@ public class ProductControllerApiV1 {
 
         @GetMapping
         public ResponseEntity<ResDTO<ResProductGetDTOApiV1>> getBy(
-                @RequestParam(name = "searchValue", required = false) String searchValue,
-                @PageableDefault(sort="id", direction = Sort.Direction.ASC) Pageable pageable
-//                Long id //TODO 권한 처리용 (추후 변경 예정)
+                @QuerydslPredicate(root = ProductEntity.class) Predicate predicate,
+                @PageableDefault(page = 0, size = 10, sort = "createdAt") Pageable pageable
         ){
-                List<ProductEntity> tempProducts = List.of(
-                        new ProductEntity(),
-                        new ProductEntity()
-                );
-
-                Page<ProductEntity> tempProductPage = new PageImpl<>(tempProducts, pageable, tempProducts.size());
-
-                ResProductGetDTOApiV1 tempResDto = ResProductGetDTOApiV1.of(tempProductPage);
+                ResProductGetDTOApiV1 responseDto = productServiceApiV1.getBy(predicate, pageable);
 
                 return new ResponseEntity<>(
                         ResDTO.<ResProductGetDTOApiV1>builder()
                                 .code(0)
                                 .message("상품 조회에 성공했습니다.")
-                                .data(tempResDto)
+                                .data(responseDto)
                                 .build(),
                         HttpStatus.OK
                 );

--- a/product-service/src/test/resources/httpclient/product.http
+++ b/product-service/src/test/resources/httpclient/product.http
@@ -72,3 +72,6 @@ Content-Type: application/json
 
 ### 6. 상품 삭제
 DELETE http://localhost:8080/v1/products/48aa06d0-f865-4a49-acf6-64c13adb389c
+
+### 7. 상품 검색 조회
+GET http://localhost:8080/v1/products?name=할인 이용권 수정1&productStatus=OPEN


### PR DESCRIPTION
### 변경 타입
* [x] 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
- 상품 검색 api에 Querydsl 기반 조건 검색 및 페이징 기능 구현
- PageableDefault를 통한 페이징 처리
- JpaRepository에 Querydsl의 Predicate를 받아 동적 쿼리 실행할 수 있도록 QuerydslPredicateExecutor 구현
- 공통레포 0.0.7버전으로 변경
- 응답 dto 객체 > dto 변환 구현


### 테스트 결과
![image](https://github.com/user-attachments/assets/063ab36b-72ea-48f9-bfec-737681e491b3)
