### PR TITLE
✨ feat [#144-product-stock-decrease] 상품-재고 차감 기능 구현

### DIFF
--- a/product-service/src/main/java/com/business/productservice/application/exception/ProductExceptionCode.java
+++ b/product-service/src/main/java/com/business/productservice/application/exception/ProductExceptionCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ProductExceptionCode implements ExceptionCode {
-    PRODUCT_NOT_FOUND("P101", "해당 상품은 없는 정보입니다.", HttpStatus.NOT_FOUND);
+    PRODUCT_NOT_FOUND("P101", "해당 상품은 없는 정보입니다.", HttpStatus.NOT_FOUND),
+    PRODUCT_STOCK_SOLDOUT("P102","해당 상품은 매진되었습니다.", HttpStatus.BAD_REQUEST),;
 
     private final String code;
     private final String message;

--- a/product-service/src/main/java/com/business/productservice/application/service/ProductServiceApiV1.java
+++ b/product-service/src/main/java/com/business/productservice/application/service/ProductServiceApiV1.java
@@ -22,4 +22,6 @@ public interface ProductServiceApiV1 {
     ResProductPutDTOApiV1 putBy(UUID id, ReqProductPutDTOApiV1 dto);
 
     void deleteBy(UUID id);
+
+    void postDecreaseById(UUID id);
 }

--- a/product-service/src/main/java/com/business/productservice/application/service/ProductServiceImplApiV1.java
+++ b/product-service/src/main/java/com/business/productservice/application/service/ProductServiceImplApiV1.java
@@ -83,4 +83,16 @@ public class ProductServiceImplApiV1 implements ProductServiceApiV1{
         stockEntity.deletedBy(1L);
     }
 
+    @Override
+    public void postDecreaseById(UUID id) {
+        StockEntity stockEntity = stockRepository.findByIdWithPessimisticLock(id)
+                .orElseThrow(() -> new CustomException(ProductExceptionCode.PRODUCT_NOT_FOUND));
+
+        if (stockEntity.getStock() <= 0) {
+            throw new CustomException(ProductExceptionCode.PRODUCT_STOCK_SOLDOUT);
+        }
+
+        stockEntity.decrease();
+    }
+
 }

--- a/product-service/src/main/java/com/business/productservice/domain/product/entity/StockEntity.java
+++ b/product-service/src/main/java/com/business/productservice/domain/product/entity/StockEntity.java
@@ -42,6 +42,8 @@ public class StockEntity extends BaseEntity {
         this.stock = quantity;
     }
 
-
+    public void decrease() {
+        this.stock--;
+    }
 
 }

--- a/product-service/src/main/java/com/business/productservice/domain/product/repository/StockRepository.java
+++ b/product-service/src/main/java/com/business/productservice/domain/product/repository/StockRepository.java
@@ -1,4 +1,10 @@
 package com.business.productservice.domain.product.repository;
 
+import com.business.productservice.domain.product.entity.StockEntity;
+
+import java.util.Optional;
+import java.util.UUID;
+
 public interface StockRepository {
+    Optional<StockEntity> findByIdWithPessimisticLock(UUID id);
 }

--- a/product-service/src/main/java/com/business/productservice/domain/product/repository/StockRepositoryImpl.java
+++ b/product-service/src/main/java/com/business/productservice/domain/product/repository/StockRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.business.productservice.domain.product.repository;
+
+import com.business.productservice.domain.product.entity.StockEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public class StockRepositoryImpl implements StockRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public Optional<StockEntity> findByIdWithPessimisticLock(UUID id) {
+        StockEntity stock = em.createQuery(
+                        "SELECT s FROM StockEntity s WHERE s.id = :id", StockEntity.class)
+                .setParameter("id", id)
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .getSingleResult();
+
+        return Optional.ofNullable(stock);
+    }
+}

--- a/product-service/src/main/java/com/business/productservice/presentation/controller/ProductControllerApiV1.java
+++ b/product-service/src/main/java/com/business/productservice/presentation/controller/ProductControllerApiV1.java
@@ -112,9 +112,9 @@ public class ProductControllerApiV1 {
 
         @PostMapping("/{id}/stocks-decrease")
         public ResponseEntity<ResDTO<Object>> postDecreaseById(
-                @PathVariable("id") UUID id,
-                @Valid @RequestBody ReqStockDecreasePostDTOApiV1 dto
+                @PathVariable("id") UUID id
         ){
+                productServiceApiV1.postDecreaseById(id);
                 return new ResponseEntity<>(
                         ResDTO.builder()
                                 .code(0)

--- a/product-service/src/test/resources/httpclient/product.http
+++ b/product-service/src/test/resources/httpclient/product.http
@@ -50,7 +50,7 @@ Content-Type: application/json
 }
 
 ### 4. 상품 단건 조회
-GET http://localhost:8080/v1/products/895a3f93-5f84-4c5c-977d-630a325f6ae3
+GET http://localhost:8080/v1/products/8982c5ab-1fb0-4989-a812-167587843a68
 
 ### 5. 상품 정보 수정
 PUT http://localhost:8080/v1/products/895a3f93-5f84-4c5c-977d-630a325f6ae3
@@ -75,3 +75,7 @@ DELETE http://localhost:8080/v1/products/48aa06d0-f865-4a49-acf6-64c13adb389c
 
 ### 7. 상품 검색 조회
 GET http://localhost:8080/v1/products?name=할인 이용권 수정1&productStatus=OPEN
+
+### 8. 상품 재고 차감 (내부 호출용) - 선착순 1인 1예매
+POST localhost:8080/v1/products/8982c5ab-1fb0-4989-a812-167587843a68/stocks-decrease
+


### PR DESCRIPTION
### 변경 타입
* [x] 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [ ] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
- 해당 id(상품id와 동일한 값)의 재고 값을 1씩 감소 시키는 비즈니스 로직 구현 - 1인 1구매 가능 (순착순 티켓팅)
- 재고가 0보다 작거나 같을 경우 예외처리 (매진 메세지)
-  재고가 1개일 때 동시에 여러 요청이 들어오는 경우 중복 차감되는 문제 방지하기 위해 비관적 락 적용
    - StockRepository의 구현체인 StockRepositoryImpl 파일 생성
    - StockRepositoryImpl에서 EntityManager로 직접 락 처리

*부하 테스트는 추후 JMeter로 진행할 예정입니다.

### 테스트 결과
![image](https://github.com/user-attachments/assets/240a3009-72fa-4017-9d44-0e66478fbafc)
