### PR TITLE
🔨 refactor[#165-themepark-error] 테마파크 에러리턴코드 리팩토링

### DIFF
--- a/themepark-service/src/main/java/com/business/themeparkservice/ThemeparkServiceApplication.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/ThemeparkServiceApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {"com.business.themeparkservice","com.github.themepark.common"})
 public class ThemeparkServiceApplication {
 
     public static void main(String[] args) {

--- a/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/exception/HashtagExceptionCode.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/exception/HashtagExceptionCode.java
@@ -1,0 +1,16 @@
+package com.business.themeparkservice.hashtag.application.exception;
+
+import com.github.themepark.common.application.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum HashtagExceptionCode implements ExceptionCode {
+    HASHTAG_NOT_FOUND("H101","존재하지않는 해시태그입니다.", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/service/HashtagServiceImplApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/hashtag/application/service/HashtagServiceImplApiV1.java
@@ -6,8 +6,10 @@ import com.business.themeparkservice.hashtag.application.dto.response.ResHashtag
 import com.business.themeparkservice.hashtag.application.dto.response.ResHashtagGetDTOApiV1;
 import com.business.themeparkservice.hashtag.application.dto.response.ResHashtagPostDTOApiV1;
 import com.business.themeparkservice.hashtag.application.dto.response.ResHashtagPutDTOApiV1;
+import com.business.themeparkservice.hashtag.application.exception.HashtagExceptionCode;
 import com.business.themeparkservice.hashtag.domain.entity.HashtagEntity;
 import com.business.themeparkservice.hashtag.infastructure.persistence.hashtag.HashtagJpaRepository;
+import com.github.themepark.common.application.exception.CustomException;
 import com.querydsl.core.types.Predicate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -57,6 +59,6 @@ public class HashtagServiceImplApiV1 implements HashtagServiceApiV1{
     }
 
     private HashtagEntity getHashtag(UUID id) {
-        return hashtagRepository.findById(id).orElseThrow(() -> new RuntimeException("Hashtag not found"));
+        return hashtagRepository.findById(id).orElseThrow(() -> new CustomException(HashtagExceptionCode.HASHTAG_NOT_FOUND));
     }
 }

--- a/themepark-service/src/main/java/com/business/themeparkservice/themepark/application/exception/ThemeparkExceptionCode.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/themepark/application/exception/ThemeparkExceptionCode.java
@@ -1,0 +1,16 @@
+package com.business.themeparkservice.themepark.application.exception;
+
+import com.github.themepark.common.application.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ThemeparkExceptionCode implements ExceptionCode {
+    THEMEPARK_NOT_FOUND("T101","존재하지않는 테마파크입니다.", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/themepark-service/src/main/java/com/business/themeparkservice/themepark/application/service/ThemeparkServiceImplApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/themepark/application/service/ThemeparkServiceImplApiV1.java
@@ -1,5 +1,6 @@
 package com.business.themeparkservice.themepark.application.service;
 
+import com.business.themeparkservice.hashtag.application.exception.HashtagExceptionCode;
 import com.business.themeparkservice.hashtag.domain.entity.HashtagEntity;
 import com.business.themeparkservice.hashtag.infastructure.persistence.hashtag.HashtagJpaRepository;
 import com.business.themeparkservice.themepark.application.dto.request.ReqThemeparkPostDTOApiV1;
@@ -8,10 +9,12 @@ import com.business.themeparkservice.themepark.application.dto.response.ResTheme
 import com.business.themeparkservice.themepark.application.dto.response.ResThemeparkGetDTOApiV1;
 import com.business.themeparkservice.themepark.application.dto.response.ResThemeparkPostDTOApiv1;
 import com.business.themeparkservice.themepark.application.dto.response.ResThemeparkPutDTOApiV1;
+import com.business.themeparkservice.themepark.application.exception.ThemeparkExceptionCode;
 import com.business.themeparkservice.themepark.domain.entity.ThemeparkEntity;
 import com.business.themeparkservice.themepark.domain.entity.ThemeparkHashtagEntity;
 import com.business.themeparkservice.themepark.infastructure.persistence.themepark.ThemeparkHashtagJpaRepository;
 import com.business.themeparkservice.themepark.infastructure.persistence.themepark.ThemeparkJpaRepository;
+import com.github.themepark.common.application.exception.CustomException;
 import com.querydsl.core.types.Predicate;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -90,9 +93,7 @@ public class ThemeparkServiceImplApiV1 implements ThemeparkServiceApiV1 {
         List<ThemeparkHashtagEntity> themeparkHashtagEntityList = new ArrayList<>();
 
         for (ReqThemeparkPutDTOApiV1.ThemePark.Hashtag tagDto : reqDto.getThemepark().getHashtagList()) {
-
-            HashtagEntity hashtagEntity = hashtagRepository.findById(tagDto.getHashtagId())
-                    .orElseThrow(()->new EntityNotFoundException("Hashtag not found"));
+            HashtagEntity hashtagEntity = findHashtag(tagDto.getHashtagId());
 
             ThemeparkHashtagEntity themeparkHashtagEntity =
                     ThemeparkHashtagEntity.builder()
@@ -116,9 +117,7 @@ public class ThemeparkServiceImplApiV1 implements ThemeparkServiceApiV1 {
         List<ThemeparkHashtagEntity> themeparkHashtagEntityList = new ArrayList<>();
 
         for (ReqThemeparkPostDTOApiV1.ThemePark.Hashtag tagDto : reqDto.getThemepark().getHashtagList()) {
-
-            HashtagEntity hashtagEntity = hashtagRepository.findById(tagDto.getHashtagId())
-                    .orElseThrow(()->new EntityNotFoundException("Hashtag not found"));
+            HashtagEntity hashtagEntity = findHashtag(tagDto.getHashtagId());
 
             ThemeparkHashtagEntity themeparkHashtagEntity =
                     ThemeparkHashtagEntity.builder()
@@ -145,8 +144,7 @@ public class ThemeparkServiceImplApiV1 implements ThemeparkServiceApiV1 {
 
 
         for (ThemeparkHashtagEntity themeparkHashtagEntity : themeparkHashtagEntityList) {
-            HashtagEntity hashtag = hashtagRepository.findById(themeparkHashtagEntity.getHashtag().getId())
-                    .orElseThrow(()->new EntityNotFoundException("Hashtag not found"));
+            HashtagEntity hashtag = findHashtag(themeparkHashtagEntity.getHashtag().getId());
 
             hashtagEntityList.add(hashtag);
         }
@@ -156,9 +154,14 @@ public class ThemeparkServiceImplApiV1 implements ThemeparkServiceApiV1 {
                 .toList();
     }
 
+    private HashtagEntity findHashtag(UUID id) {
+        return hashtagRepository.findById(id)
+                .orElseThrow(()->new CustomException(HashtagExceptionCode.HASHTAG_NOT_FOUND));
+    }
+
 
     private ThemeparkEntity findThemepark(UUID id) {
         return themeparkRepository.findById(id)
-                .orElseThrow(()->new EntityNotFoundException("Themepark not found"));
+                .orElseThrow(()->new CustomException(ThemeparkExceptionCode.THEMEPARK_NOT_FOUND));
     }
 }

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/application/exception/WaitingExceptionCode.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/application/exception/WaitingExceptionCode.java
@@ -1,0 +1,16 @@
+package com.business.themeparkservice.waiting.application.exception;
+
+import com.github.themepark.common.application.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum WaitingExceptionCode implements ExceptionCode {
+    WAITING_NOT_FOUND("W101","존재하지않는 대기열입니다.", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/application/service/WaitingServiceImplApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/application/service/WaitingServiceImplApiV1.java
@@ -10,7 +10,6 @@ import com.business.themeparkservice.waiting.domain.vo.WaitingStatus;
 import com.business.themeparkservice.waiting.infastructure.persistence.waiting.WaitingJpaRepository;
 import com.github.themepark.common.application.exception.CustomException;
 import com.querydsl.core.types.Predicate;
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/application/service/WaitingServiceImplApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/application/service/WaitingServiceImplApiV1.java
@@ -1,11 +1,14 @@
 package com.business.themeparkservice.waiting.application.service;
 
+import com.business.themeparkservice.themepark.application.exception.ThemeparkExceptionCode;
 import com.business.themeparkservice.themepark.infastructure.persistence.themepark.ThemeparkJpaRepository;
 import com.business.themeparkservice.waiting.application.dto.request.ReqWaitingPostDTOApiV1;
 import com.business.themeparkservice.waiting.application.dto.response.*;
+import com.business.themeparkservice.waiting.application.exception.WaitingExceptionCode;
 import com.business.themeparkservice.waiting.domain.entity.WaitingEntity;
 import com.business.themeparkservice.waiting.domain.vo.WaitingStatus;
 import com.business.themeparkservice.waiting.infastructure.persistence.waiting.WaitingJpaRepository;
+import com.github.themepark.common.application.exception.CustomException;
 import com.querydsl.core.types.Predicate;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.constraints.NotNull;
@@ -83,7 +86,7 @@ public class WaitingServiceImplApiV1 implements WaitingServiceApiV1{
 
     private WaitingEntity findByIdAndStatus(UUID id, WaitingStatus waitingStatus) {
         return waitingRepository.findByIdAndWaitingStatus(id,waitingStatus)
-                .orElseThrow(() -> new RuntimeException("요청하신 대기정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(WaitingExceptionCode.WAITING_NOT_FOUND));
     }
 
 
@@ -94,6 +97,6 @@ public class WaitingServiceImplApiV1 implements WaitingServiceApiV1{
 
     private void ThemeparkChecking(@NotNull(message = "테마파크번호를 입력해주세요") UUID themeparkId) {
         themeparkRepository.findById(themeparkId).orElseThrow(
-                ()->new EntityNotFoundException("Themepark not found"));
+                ()->new CustomException(ThemeparkExceptionCode.THEMEPARK_NOT_FOUND));
     }
 }


### PR DESCRIPTION
### 변경 타입
* [X] 기능 추가/수정
* [ ] 버그 수정
* [X] 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [X] 코드 작성 가이드라인을 준수했는가?
* [X] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 테마파크,해시태그,대기열 커스텀 에러리턴코드 작성
- 테마파크,해시태그,대기열 커스텀 에러리턴코드 적용
- 응답 리턴코드 적용을위한 scanbasePackages 경로 추가
- 
### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

<img width="670" alt="스크린샷 2025-04-16 오후 2 13 35" src="https://github.com/user-attachments/assets/83a1d425-a251-45b2-bd57-11bd055fdaad" />