### PR TITLE
🔨 refactor [#214-gateway-jwt] jwt 필터에 HTTP 메소드별 경로 제외 설정 추가

### DIFF
--- a/gateway-service/src/main/java/com/business/gatewayservice/infrastructure/filter/CustomPreFilter.java
+++ b/gateway-service/src/main/java/com/business/gatewayservice/infrastructure/filter/CustomPreFilter.java
@@ -53,8 +53,8 @@ public class CustomPreFilter implements GlobalFilter, Ordered {
     private static final Map<HttpMethod, List<String>> EXCLUDED_PATHS_BY_METHOD = Map.of(
         HttpMethod.GET, List.of(
             "/v1/products/*",
-            "/v1/themeparks/**",
-            "/v1/hashtags/**",
+            "/v1/themeparks/*",
+            "/v1/hashtags/*",
             "/v1/auth/refresh",
             "/springdoc/openapi3-user-service.json"
         ),

--- a/gateway-service/src/main/java/com/business/gatewayservice/infrastructure/filter/CustomPreFilter.java
+++ b/gateway-service/src/main/java/com/business/gatewayservice/infrastructure/filter/CustomPreFilter.java
@@ -52,6 +52,7 @@ public class CustomPreFilter implements GlobalFilter, Ordered {
     // JWT 인증을 적용하지 않을 경로 목록
     private static final Map<HttpMethod, List<String>> EXCLUDED_PATHS_BY_METHOD = Map.of(
         HttpMethod.GET, List.of(
+            "/v1/products",
             "/v1/products/*",
             "/v1/themeparks/*",
             "/v1/hashtags/*",
@@ -156,7 +157,11 @@ public class CustomPreFilter implements GlobalFilter, Ordered {
 
     private boolean isExcludedPath(String path, HttpMethod method) {
         List<String> excludedPaths = EXCLUDED_PATHS_BY_METHOD.get(method);
-        if (excludedPaths == null || excludedPaths.isEmpty()) return false;
+        if (excludedPaths == null || excludedPaths.isEmpty()) {
+            log.info("excludedPaths NULL");
+            return false;
+        }
+        log.info("excludedPaths.stream().anyMatch(pattern -> matcher.match(pattern, path)): {}", excludedPaths.stream().anyMatch(pattern -> matcher.match(pattern, path)));
         return excludedPaths.stream().anyMatch(pattern -> matcher.match(pattern, path));
     }
 


### PR DESCRIPTION
### 변경 타입
* [x] 기능 추가/수정
* [ ] 버그 수정
* [x] 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
- 메소드별로 jwt 인증 제외 경로를 설정했습니다.
![스크린샷 2025-04-18 오후 3 55 17](https://github.com/user-attachments/assets/f9b19a2c-0275-4168-b596-4e93ab8ac1ac)
### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
