### PR TITLE
🔨 refactor[#251-waiting-lock] 대기열 동시성 리팩토링

### DIFF
--- a/themepark-service/build.gradle
+++ b/themepark-service/build.gradle
@@ -38,7 +38,9 @@ configurations {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.postgresql:postgresql'
     runtimeOnly 'org.postgresql:postgresql'
+    implementation 'org.springframework.retry:spring-retry'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'

--- a/themepark-service/src/main/java/com/business/themeparkservice/ThemeparkServiceApplication.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/ThemeparkServiceApplication.java
@@ -3,8 +3,12 @@ package com.business.themeparkservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 
+@EnableAspectJAutoProxy
+@EnableRetry
 @EnableFeignClients
 @SpringBootApplication(scanBasePackages = {"com.business.themeparkservice","com.github.themepark.common"})
 public class ThemeparkServiceApplication {

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/application/service/WaitingServiceImplApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/application/service/WaitingServiceImplApiV1.java
@@ -33,16 +33,12 @@ public class WaitingServiceImplApiV1 implements WaitingServiceApiV1{
 
     private final ThemeparkJpaRepository themeparkRepository;
 
-    @Autowired
-    private EntityManager entityManager;
-
     @Transactional(isolation = Isolation.SERIALIZABLE)
     @Override
     public ResWaitingPostDTOApiV1 postBy(ReqWaitingPostDTOApiV1 reqDto,Long userId) {
         UUID themeparkId = reqDto.getWaiting().getThemeparkId();
         ThemeparkChecking(themeparkId);
 //        WaitingChecking(reqDto,userId);
-
 
         WaitingEntity waitingInfo
                 = waitingRepository.findLastWaitingNumber(themeparkId, WaitingStatus.WAITING).orElse(null);

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/domain/repository/WaitingRepository.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/domain/repository/WaitingRepository.java
@@ -3,13 +3,23 @@ package com.business.themeparkservice.waiting.domain.repository;
 import com.business.themeparkservice.waiting.domain.entity.WaitingEntity;
 import com.business.themeparkservice.waiting.domain.vo.WaitingStatus;
 import feign.Param;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import jakarta.validation.constraints.NotNull;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface WaitingRepository {
+
+    @Query(value = "select * from themepark_service.p_waitings w where w.themepark_id = :themeparkId and w.waiting_status = 'WAITING' order by w.waiting_number desc limit 1 for update ",nativeQuery = true)
+    Optional<WaitingEntity> findLastWaitingNumber(UUID themeparkId,WaitingStatus waitingStatus);
+
     int countByThemeparkIdAndWaitingStatus(@NotNull(message = "테마파크번호를 입력해주세요") UUID themeparkId,WaitingStatus waitingStatus);
 
     int countByThemeparkIdAndUserIdAndWaitingStatus(UUID themeparkId, Long userId,WaitingStatus waitingStatus);
@@ -17,9 +27,6 @@ public interface WaitingRepository {
     @Query("select count(*) from WaitingEntity w " +
             "where w.waitingNumber < :waitingNumber AND w.themeparkId = :themeparkId AND w.waitingStatus = 'WAITING'")
     int checkingMyWaitingLeft(Integer waitingNumber,UUID themeparkId);
-
-    @Query("SELECT COALESCE(MAX(w.waitingNumber), 0) FROM WaitingEntity w WHERE w.themeparkId = :themeparkId AND w.waitingStatus = 'WAITING'")
-    int findLastWaitingNumber(@NotNull(message = "테마파크번호를 입력해주세요") UUID themeparkId);
 
     Optional<WaitingEntity> findByIdAndWaitingStatus(UUID id,WaitingStatus waitingStatus);
 }

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/domain/repository/WaitingRepository.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/domain/repository/WaitingRepository.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 
 public interface WaitingRepository {
 
-    @Query(value = "select * from themepark_service.p_waitings w where w.themepark_id = :themeparkId and w.waiting_status = 'WAITING' order by w.waiting_number desc limit 1 for update ",nativeQuery = true)
+    @Query(value = "select * from themepark_service.p_waitings w where w.themepark_id = :themeparkId and w.waiting_status = 'WAITING' order by w.waiting_number desc limit 1 for share",nativeQuery = true)
     Optional<WaitingEntity> findLastWaitingNumber(UUID themeparkId,WaitingStatus waitingStatus);
 
     int countByThemeparkIdAndWaitingStatus(@NotNull(message = "테마파크번호를 입력해주세요") UUID themeparkId,WaitingStatus waitingStatus);


### PR DESCRIPTION
### 변경 타입
* [X] 기능 추가/수정
* [X] 버그 수정
* [X] 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [X] 코드 작성 가이드라인을 준수했는가?
* [X] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- 비관적 락 적용을 위한 repository,service 수정
-  springboot 기본 aop 어노테이션 추가
- 오류 발생시 재시도할수있도록 enableretry 어노테이션 추가
- for share 를 사용하여 접근성 완화
- 오류 클래스 작성을위한 postgresql 의존성 추가
**현재 동시성 테스트 진행을 위해 회원대기 중복체크 부분을 주석처리해두었습니다!**

---
### 진행 중 발생한 문제1

**락이 걸린것을 확인하기위해 sql 로그를 보던 중 for update 가 아닌 그보다 더 낮은 수준의 락인 for no key update 발생**
-> 해당 이슈를 수정하기위해 native 쿼리문으로 작성진행하였습니다.
-> for share 로 변경하여 동시성 개선

<img width="859" alt="스크린샷 2025-04-23 오후 1 14 45" src="https://github.com/user-attachments/assets/caeb5cb5-01fd-4432-8571-249eb79489a3" />

### 결과

<img width="411" alt="1 fon update" src="https://github.com/user-attachments/assets/aaf27ae1-1974-4e1f-bceb-18d989dd29b1" />

---
### 진행 중 발생한 문제2
**락은 정상적으로 걸렸으나, 다수의 트랜잭션이 조회하는 문제는 해결이 되지않아 값이 중복저장되는 문제발생 **
-> 트랜잭션의 격리수준이 낮아 발생한 문제로  `@Transactional(isolation = Isolation.SERIALIZABLE)` 을 사용
-> 직렬화 에러가 발생하여 이를 해결하기위해 `@Retryable` 을 추가하였습니다.
-> @Retryable 어노테이션이 붙은 빈(Bean)에 대한 프록시 객체를 생성하기위해 springboot 기본 aop를 추가하였습니다.

격리수준을 SERIALIZABLE 로 올리면 하나의 트랜잭션 수행중 다른트랜잭션이 읽는것을 방지할 수있습니다.
하지만 가장 강력한 격리수준이어서 데이터의 일관성을 엄격하게 보장해야 하는 특정 트랜잭션에 한정적으로 사용하는 것을 권장합니다.

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

<img width="400" alt="스크린샷 2025-04-23 오전 11 54 38" src="https://github.com/user-attachments/assets/100328c6-ee61-4c99-a551-7e3a499f9240" />

<img width="266" alt="스크린샷 2025-04-23 오후 1 15 10" src="https://github.com/user-attachments/assets/0a4a0bda-d917-4749-a377-7855a6f9715f" />
