### PR TITLE
✨ feat [#261 slack] Slack EventType, Template Redis에 저장

### DIFF
--- a/slack-service/build.gradle
+++ b/slack-service/build.gradle
@@ -36,6 +36,9 @@ configurations {
 }
 
 dependencies {
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     implementation 'com.github.numberOnethemepark:common:0.2.1'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/slack-service/src/main/java/com/business/slackservice/infrastructure/config/RedisConfig.java
+++ b/slack-service/src/main/java/com/business/slackservice/infrastructure/config/RedisConfig.java
@@ -1,0 +1,27 @@
+package com.business.slackservice.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+}

--- a/slack-service/src/main/java/com/business/slackservice/infrastructure/persistence/SlackRedisRepository.java
+++ b/slack-service/src/main/java/com/business/slackservice/infrastructure/persistence/SlackRedisRepository.java
@@ -1,0 +1,12 @@
+package com.business.slackservice.infrastructure.persistence;
+
+import com.business.slackservice.domain.slackEventType.entity.SlackEventTypeEntity;
+import com.business.slackservice.domain.slackTemplate.entity.SlackTemplateEntity;
+import java.util.Optional;
+
+public interface SlackRedisRepository {
+    void saveSlackEventType(SlackEventTypeEntity slackEventType);
+    void saveSlackTemplate(SlackTemplateEntity template);
+    Optional<String> findSlackEventTypeByName(String name);
+    Optional<String> findSlackTemplateByEventType(String eventType);
+}

--- a/slack-service/src/main/java/com/business/slackservice/infrastructure/persistence/SlackRedisRepositoryImpl.java
+++ b/slack-service/src/main/java/com/business/slackservice/infrastructure/persistence/SlackRedisRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.business.slackservice.infrastructure.persistence;
+
+import com.business.slackservice.domain.slackEventType.entity.SlackEventTypeEntity;
+import com.business.slackservice.domain.slackTemplate.entity.SlackTemplateEntity;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SlackRedisRepositoryImpl implements SlackRedisRepository {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final String EVENT_TYPE_PREFIX = "slack:event:";
+    private final String TEMPLATE_PREFIX = "slack:template:";
+
+    @Override
+    public void saveSlackEventType(SlackEventTypeEntity slackEventType) {
+        redisTemplate.opsForValue().set(EVENT_TYPE_PREFIX + slackEventType.getName(), slackEventType.getId());
+    }
+
+    @Override
+    public void saveSlackTemplate(SlackTemplateEntity template) {
+        redisTemplate.opsForValue().set(TEMPLATE_PREFIX + template.getSlackEventTypeEntity().getName(), template.getContent());
+    }
+
+    @Override
+    public Optional<String> findSlackEventTypeByName(String name) {
+        return Optional.ofNullable((String) redisTemplate.opsForValue().get(EVENT_TYPE_PREFIX + name));
+    }
+
+    @Override
+    public Optional<String> findSlackTemplateByEventType(String eventType) {
+        return Optional.ofNullable((String) redisTemplate.opsForValue().get(TEMPLATE_PREFIX + eventType));
+    }
+}


### PR DESCRIPTION
### 변경 타입
* [x] 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
- 자주 조회되는 슬랙 이벤트 타입과 템플릿을 Redis에 저장했습니다.
- Redis에 저장되어있지 않은 경우 RDB에서 조회해서 Redis에 저장됩니다.
 [Key] slack:event:이벤트타입이름 [Value] 이벤트타입ID
 [Key] slack:template:이벤트타입이름 [Value] 템플릿 양식

### 테스트 결과
JMeter로 성능 테스트를 진행한 결과 Redis 적용 전에는 평균 처리량이 416 req/sec였으나, 적용 후에는 평균 897 req/sec로 약 두 배 향상되었습니다. 
![스크린샷 2025-04-24 오전 11 31 50](https://github.com/user-attachments/assets/5d50e168-9e85-4106-9b96-cdb347d67004)
