### PR TITLE
✨ feat [#255-waiting-lock] 대기열 redis 분산락 캐싱 적용

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,14 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
-
+  redis-stack:
+    image: redis/redis-stack
+    container_name: redis-stack
+    restart: always
+    environment:
+      REDIS_ARGS: "--requirepass systempass"
+    ports:
+      - 6379:6379
+      - 8009:8009
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,14 +11,5 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
-  redis-stack:
-    image: redis/redis-stack
-    container_name: redis-stack
-    restart: always
-    environment:
-      REDIS_ARGS: "--requirepass systempass"
-    ports:
-      - 6379:6379
-      - 8009:8009
 volumes:
   pgdata:

--- a/themepark-service/build.gradle
+++ b/themepark-service/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     implementation 'org.springframework.retry:spring-retry'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.23.4'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 

--- a/themepark-service/src/main/java/com/business/themeparkservice/ThemeparkServiceApplication.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/ThemeparkServiceApplication.java
@@ -5,12 +5,16 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.retry.annotation.EnableRetry;
 
 @EnableAspectJAutoProxy
 @EnableRetry
 @EnableFeignClients
 @SpringBootApplication(scanBasePackages = {"com.business.themeparkservice","com.github.themepark.common"})
+@EnableJpaRepositories(basePackages = "com.business.themeparkservice.**.infastructure.persistence.**")
+@EnableRedisRepositories(basePackages = "com.business.themeparkservice.waiting.infastructure.redis")
 public class ThemeparkServiceApplication {
 
     public static void main(String[] args) {

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/application/dto/request/ReqWaitingPostDTOApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/application/dto/request/ReqWaitingPostDTOApiV1.java
@@ -1,6 +1,7 @@
 package com.business.themeparkservice.waiting.application.dto.request;
 
 import com.business.themeparkservice.waiting.domain.entity.WaitingEntity;
+import com.business.themeparkservice.waiting.domain.entity.WaitingRedisEntity;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -20,7 +21,7 @@ public class ReqWaitingPostDTOApiV1 {
     @NotNull(message = "대기정보를 입력해주세요")
     private Waiting waiting;
 
-    public WaitingEntity createWaiting(int waitingNumber, int waitingLeft,Long userId) {
+    public WaitingEntity createWaiting(int waitingNumber, int waitingLeft, Long userId) {
         return WaitingEntity.builder()
                 .userId(userId)
                 .themeparkId(waiting.themeparkId)
@@ -28,7 +29,6 @@ public class ReqWaitingPostDTOApiV1 {
                 .waitingNumber(waitingNumber)
                 .build();
     }
-
 
     @Getter
     @Builder

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/application/exception/WaitingExceptionCode.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/application/exception/WaitingExceptionCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum WaitingExceptionCode implements ExceptionCode {
     WAITING_NOT_FOUND("W101","존재하지않는 대기열입니다.", HttpStatus.NOT_FOUND),
-    WAITING_STILL_HERE("W102","이미 대기중 입니다.", HttpStatus.CONFLICT);
+    WAITING_DUPLICATE("W102","이미 대기중 입니다.", HttpStatus.CONFLICT),
+    WAITING_LOCK_FAILED("W103","요청량이 많습니다 잠시후에 다시 시도해주세요.", HttpStatus.CONFLICT);
 
     private final String code;
     private final String message;

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/application/service/WaitingServiceImplApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/application/service/WaitingServiceImplApiV1.java
@@ -40,12 +40,7 @@ public class WaitingServiceImplApiV1 implements WaitingServiceApiV1{
 
     private final RedissonClient redissonClient;
 
-    @Retryable(
-            value = { org.springframework.dao.CannotAcquireLockException.class, org.postgresql.util.PSQLException.class },
-            maxAttempts = 5,
-            backoff = @Backoff(delay = 400, multiplier = 2)
-    )
-    @Transactional(isolation = Isolation.SERIALIZABLE)
+    @Transactional
     @Override
     public ResWaitingPostDTOApiV1 postBy(ReqWaitingPostDTOApiV1 reqDto,Long userId) {
         UUID themeparkId = reqDto.getWaiting().getThemeparkId();

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/application/service/WaitingServiceImplApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/application/service/WaitingServiceImplApiV1.java
@@ -6,12 +6,16 @@ import com.business.themeparkservice.waiting.application.dto.request.ReqWaitingP
 import com.business.themeparkservice.waiting.application.dto.response.*;
 import com.business.themeparkservice.waiting.application.exception.WaitingExceptionCode;
 import com.business.themeparkservice.waiting.domain.entity.WaitingEntity;
+import com.business.themeparkservice.waiting.domain.entity.WaitingRedisEntity;
 import com.business.themeparkservice.waiting.domain.vo.WaitingStatus;
 import com.business.themeparkservice.waiting.infastructure.persistence.waiting.WaitingJpaRepository;
+import com.business.themeparkservice.waiting.infastructure.redis.WaitingCrudRedisRepository;
 import com.github.themepark.common.application.exception.CustomException;
 import com.querydsl.core.types.Predicate;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.retry.annotation.Backoff;
@@ -21,6 +25,7 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @Transactional
@@ -29,7 +34,11 @@ public class WaitingServiceImplApiV1 implements WaitingServiceApiV1{
 
     private final WaitingJpaRepository waitingRepository;
 
+    private final WaitingCrudRedisRepository waitingRedisRepository;
+
     private final ThemeparkJpaRepository themeparkRepository;
+
+    private final RedissonClient redissonClient;
 
     @Retryable(
             value = { org.springframework.dao.CannotAcquireLockException.class, org.postgresql.util.PSQLException.class },
@@ -43,17 +52,52 @@ public class WaitingServiceImplApiV1 implements WaitingServiceApiV1{
         ThemeparkChecking(themeparkId);
 //        WaitingChecking(reqDto,userId);
 
-        WaitingEntity waitingInfo
-                = waitingRepository.findLastWaitingNumber(themeparkId, WaitingStatus.WAITING).orElse(null);
+        RLock lock = redissonClient.getLock("lock:waiting:themeparkId:" + themeparkId);
+        int waitingNumber = 1;
+        int waitingLeft = 0;
 
-        int waitingLeft = (waitingInfo != null) ? waitingInfo.getWaitingLeft()+1 : 0;
-        int waitingNumber = (waitingInfo != null) ? waitingInfo.getWaitingNumber()+1 : 1;
+        try{
+            boolean lockChecking = lock.tryLock(5, TimeUnit.SECONDS);
 
-        WaitingEntity waitingEntity = reqDto.createWaiting(waitingNumber,waitingLeft,userId);
+            if(!lockChecking){
+                throw new CustomException(WaitingExceptionCode.WAITING_LOCK_FAILED);
+            }
 
-        waitingRepository.save(waitingEntity);
+            WaitingRedisEntity waitingRedisEntity =
+                    waitingRedisRepository.findById(String.valueOf(themeparkId))
+                            .orElse(null);
 
-        return ResWaitingPostDTOApiV1.of(waitingEntity);
+            if (waitingRedisEntity != null) {
+                waitingLeft = waitingRedisEntity.getWaitingLeft()+1;
+                waitingNumber = waitingRedisEntity.getWaitingNumber()+1;
+            }else {
+                WaitingEntity waitingInfo = waitingRepository.findLastWaitingNumber(themeparkId, WaitingStatus.WAITING)
+                        .orElse(null);
+
+                if (waitingInfo != null) {
+                    waitingLeft = waitingInfo.getWaitingLeft()+1;
+                    waitingNumber = waitingInfo.getWaitingNumber()+1;
+                }
+            }
+
+            waitingRedisRepository.save(WaitingRedisEntity.builder()
+                    .id(String.valueOf(themeparkId))
+                    .waitingNumber(waitingNumber)
+                    .waitingLeft(waitingLeft)
+                    .build());
+
+            WaitingEntity waitingEntity = reqDto.createWaiting(waitingNumber,waitingLeft,userId);
+
+            waitingRepository.save(waitingEntity);
+
+            return ResWaitingPostDTOApiV1.of(waitingEntity);
+
+        }catch (Exception e){
+            e.printStackTrace();
+        }finally {
+            lock.unlock();
+        }
+        return null;
     }
 
     @Override
@@ -102,7 +146,7 @@ public class WaitingServiceImplApiV1 implements WaitingServiceApiV1{
     private void WaitingChecking(ReqWaitingPostDTOApiV1 reqDto, Long userId) {
         if(waitingRepository.countByThemeparkIdAndUserIdAndWaitingStatus(
                 reqDto.getWaiting().getThemeparkId(),userId,WaitingStatus.WAITING)!= 0){
-            throw new CustomException(WaitingExceptionCode.WAITING_STILL_HERE);
+            throw new CustomException(WaitingExceptionCode.WAITING_DUPLICATE);
         }
     }
 

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/domain/entity/WaitingRedisEntity.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/domain/entity/WaitingRedisEntity.java
@@ -1,0 +1,28 @@
+package com.business.themeparkservice.waiting.domain.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import java.io.Serializable;
+
+@Getter
+@NoArgsConstructor
+@RedisHash("waiting:themeparkId")
+public class WaitingRedisEntity implements Serializable {
+
+    @Id
+    private String id;
+
+    private Integer waitingNumber;
+    private Integer waitingLeft;
+
+    @Builder
+    public WaitingRedisEntity(String id,Integer waitingNumber, Integer waitingLeft) {
+        this.id = id;
+        this.waitingNumber = waitingNumber;
+        this.waitingLeft = waitingLeft;
+    }
+}

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/domain/repository/WaitingRedisRepository.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/domain/repository/WaitingRedisRepository.java
@@ -1,0 +1,4 @@
+package com.business.themeparkservice.waiting.domain.repository;
+
+public interface WaitingRedisRepository {
+}

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/infastructure/feign/SlackFeignClientApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/infastructure/feign/SlackFeignClientApiV1.java
@@ -1,6 +1,6 @@
 package com.business.themeparkservice.waiting.infastructure.feign;
 
-import com.business.themeparkservice.waiting.infastructure.dto.request.ReqSlackPostDTOApiV1;
+import com.business.themeparkservice.waiting.infastructure.feign.dto.request.ReqSlackPostDTOApiV1;
 import com.github.themepark.common.infrastructure.config.FeignConfig;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/infastructure/feign/dto/request/ReqSlackPostDTOApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/infastructure/feign/dto/request/ReqSlackPostDTOApiV1.java
@@ -1,10 +1,8 @@
-package com.business.themeparkservice.waiting.infastructure.dto.request;
+package com.business.themeparkservice.waiting.infastructure.feign.dto.request;
 
-import com.business.themeparkservice.waiting.infastructure.vo.TargetType;
+import com.business.themeparkservice.waiting.infastructure.feign.vo.TargetType;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.UUID;
 
 @Getter
 public class ReqSlackPostDTOApiV1 {

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/infastructure/feign/service/SlackFeignClientServiceApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/infastructure/feign/service/SlackFeignClientServiceApiV1.java
@@ -1,4 +1,4 @@
-package com.business.themeparkservice.waiting.infastructure.service;
+package com.business.themeparkservice.waiting.infastructure.feign.service;
 
 import com.business.themeparkservice.themepark.application.exception.ThemeparkExceptionCode;
 import com.business.themeparkservice.themepark.domain.entity.ThemeparkEntity;
@@ -6,7 +6,7 @@ import com.business.themeparkservice.themepark.infastructure.persistence.themepa
 import com.business.themeparkservice.waiting.application.exception.WaitingExceptionCode;
 import com.business.themeparkservice.waiting.domain.entity.WaitingEntity;
 import com.business.themeparkservice.waiting.domain.vo.WaitingStatus;
-import com.business.themeparkservice.waiting.infastructure.dto.request.ReqSlackPostDTOApiV1;
+import com.business.themeparkservice.waiting.infastructure.feign.dto.request.ReqSlackPostDTOApiV1;
 import com.business.themeparkservice.waiting.infastructure.feign.SlackFeignClientApiV1;
 import com.business.themeparkservice.waiting.infastructure.persistence.waiting.WaitingJpaRepository;
 import com.github.themepark.common.application.exception.CustomException;

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/infastructure/feign/vo/TargetType.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/infastructure/feign/vo/TargetType.java
@@ -1,4 +1,4 @@
-package com.business.themeparkservice.waiting.infastructure.vo;
+package com.business.themeparkservice.waiting.infastructure.feign.vo;
 
 import lombok.RequiredArgsConstructor;
 

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/infastructure/persistence/waiting/WaitingJpaRepository.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/infastructure/persistence/waiting/WaitingJpaRepository.java
@@ -1,6 +1,5 @@
 package com.business.themeparkservice.waiting.infastructure.persistence.waiting;
 
-import com.business.themeparkservice.themepark.domain.entity.ThemeparkEntity;
 import com.business.themeparkservice.waiting.domain.entity.WaitingEntity;
 import com.business.themeparkservice.waiting.domain.repository.WaitingRepository;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/infastructure/redis/WaitingCrudRedisRepository.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/infastructure/redis/WaitingCrudRedisRepository.java
@@ -1,0 +1,12 @@
+package com.business.themeparkservice.waiting.infastructure.redis;
+
+import com.business.themeparkservice.waiting.domain.entity.WaitingRedisEntity;
+import com.business.themeparkservice.waiting.domain.repository.WaitingRedisRepository;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface WaitingCrudRedisRepository extends CrudRepository<WaitingRedisEntity, String>, WaitingRedisRepository {
+}

--- a/themepark-service/src/main/java/com/business/themeparkservice/waiting/presentation/controller/WaitingControllerApiV1.java
+++ b/themepark-service/src/main/java/com/business/themeparkservice/waiting/presentation/controller/WaitingControllerApiV1.java
@@ -4,7 +4,7 @@ import com.business.themeparkservice.themepark.domain.entity.ThemeparkEntity;
 import com.business.themeparkservice.waiting.application.dto.request.ReqWaitingPostDTOApiV1;
 import com.business.themeparkservice.waiting.application.dto.response.*;
 import com.business.themeparkservice.waiting.application.service.WaitingServiceApiV1;
-import com.business.themeparkservice.waiting.infastructure.service.SlackFeignClientServiceApiV1;
+import com.business.themeparkservice.waiting.infastructure.feign.service.SlackFeignClientServiceApiV1;
 import com.github.themepark.common.application.aop.annotation.ApiPermission;
 import com.github.themepark.common.application.dto.ResDTO;
 import com.querydsl.core.types.Predicate;

--- a/themepark-service/src/main/resources/application-dev.yml
+++ b/themepark-service/src/main/resources/application-dev.yml
@@ -6,9 +6,7 @@ spring:
     username: admin
     password: 12345
     driver-class-name: org.postgresql.Driver
-
   jpa:
-
     hibernate:
       ddl-auto: update
     show-sql: true
@@ -17,6 +15,12 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
         default_schema: themepark_service
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      username: default
+      password: systempass
 
 eureka:
   client:


### PR DESCRIPTION
### 변경 타입
* [X] 기능 추가/수정
* [ ] 버그 수정
* [X] 리팩토링
* [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [X] 코드 작성 가이드라인을 준수했는가?
* [X] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- redis 실행을 위한 docker-compose.yml 설정
- 서비스와의 연동을 위한 application-dev.yml 설정
- 분산락 적용을위한 redisson 의존성 설정
- redisRepository 와 일반 데이터베이스 repository 분리
- repositroy 분리로인한 빈 추가 오류가 발생하여 패키지 경로를 직접 작성하여 어노테이션 작성
- redis 캐싱 저장용 엔티티 작성
- 기존 비관적 락을 적용했던 대기열 생성 api를 redisson 분산 락과 합쳐서 활용
- 커스텀 에러코드 작성

**redis-> docker 로 적용하여 진행 중 게이트웨이에서 redis정보를 찾을수없다는 에러가 발생하여 
yml에 redis 정보를 추가하여 진행했었습니다. 현재 롤백한뒤 코드를 올린상황이며, 동일한 오류가 발생하는경우 
gateway에 redis 정보를 입력 하여 진행해야할것 같습니다**

### 테스트 결과

### redis 대기정보 캐싱의 경우 hashset으로 저장되도록 구현했습니다
[waiting:themepark:{themeparkId} 형식의 키값]

<img width="523" alt="스크린샷 2025-04-25 오전 3 00 46" src="https://github.com/user-attachments/assets/4059da7a-f240-4e63-b5f9-336e868ddb69" />

---

### 캐싱 적용 후 TPS 287.8/sec로 상승.

<img width="856" alt="스크린샷 2025-04-25 오전 3 39 41" src="https://github.com/user-attachments/assets/e5b2c2b6-c9d6-4519-870a-a3feb8301f4e" />
