### PR TITLE
✏️ fix [#274-user] 토큰 만료 시간 계산 시 초에서 밀리초 단위 변환 누락 수정

### DIFF
--- a/user-service/src/main/java/com/business/userservice/infrastructure/jwt/JwtUtil.java
+++ b/user-service/src/main/java/com/business/userservice/infrastructure/jwt/JwtUtil.java
@@ -110,7 +110,7 @@ public class JwtUtil {
     }
 
     private Date getExpiryDateFromNow(Long expiresIn) {
-        return new Date(System.currentTimeMillis() + expiresIn);
+        return new Date(System.currentTimeMillis() + expiresIn * 1000);
     }
 
     private String removeBearerPrefix(String token) {


### PR DESCRIPTION
### 변경 타입
* [x] 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
token 생성 시 기대했던 만료 시간과 일치하지 않는 문제가 발생했습니다.
System.currentTimeMillis()는 밀리초 단위인데 TokenExpiration에서 받은 값은 초 단위라서 그랬던 거였고
iat도 밀리초 기반이기 때문에 만료시간 계산할 때 초에서 밀리초로 변환하기 위해 * 1000을 추가했습니다.

### 테스트 결과
Access Token
![스크린샷 2025-04-26 오후 5 06 23](https://github.com/user-attachments/assets/2e847624-87d4-4ddc-9af2-204aef5698b6)
만료일: 1일

Refresh Token
![스크린샷 2025-04-26 오후 5 06 37](https://github.com/user-attachments/assets/bdaaaebe-aa74-481a-9300-deeeca60a89b)
만료일: 12일
