### PR TITLE
⚙ setting [#279 common] Prometheus와 Grafana를 이용한 모니터링

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,5 +58,31 @@ services:
       KAFKA_CLUSTERS_0_READONLY: "false"
       SERVER_PORT: 8089
 
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    ports:
+      - "9090:9090"  # Prometheus 기본 포트
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml  #호스트의 prometheus.yml 파일을 컨테이너에 마운트
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'  # 설정 파일 경로 설정
+    networks:
+      - prometheus-network  # Prometheus를 prometheus-network에 연결
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    networks:
+      - prometheus-network  # Grafana를 prometheus-network에 연결
+
 volumes:
   pgdata:
+
+networks:
+  prometheus-network:
+    external: false  # 내부 네트워크로 설정

--- a/eureka-server/build.gradle
+++ b/eureka-server/build.gradle
@@ -21,6 +21,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	// actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	// prometheus
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 
 ext {

--- a/eureka-server/src/main/resources/application.yml
+++ b/eureka-server/src/main/resources/application.yml
@@ -11,3 +11,9 @@ eureka:
     fetch-registry: false
     service-url:
       defaultZone: http://localhost:8761/eureka/
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: 'prometheus'

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -42,6 +42,10 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok:1.18.36'
     annotationProcessor 'org.projectlombok:lombok:1.18.36'
+    // actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    // prometheus
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 
 ext {

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -76,3 +76,9 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:8761/eureka/
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: 'prometheus'

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,38 @@
+global:
+  scrape_interval: 15s  # 메트릭 수집 주기
+
+scrape_configs:
+  - job_name: 'eureka'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: [ 'host.docker.internal:8761' ]  # Eureka Server 메트릭 엔드포인트
+
+  - job_name: 'gateway-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8080']  # Gateway Service 메트릭 엔드포인트
+
+  - job_name: 'user-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8001']  # User Service 메트릭 엔드포인트
+
+  - job_name: 'order-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8002']  # Order Service 메트릭 엔드포인트
+
+  - job_name: 'product-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8004']  # Product Service 메트릭 엔드포인트
+
+  - job_name: 'themepark-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8005']  # ThemePark Service 메트릭 엔드포인트
+
+  - job_name: 'slack-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8006']  # Slack Service 메트릭 엔드포인트

--- a/slack-service/build.gradle
+++ b/slack-service/build.gradle
@@ -57,6 +57,10 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
     // Slack
     implementation 'com.slack.api:slack-api-client:1.45.3'
+    // actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    // prometheus
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
     compileOnly 'org.projectlombok:lombok:1.18.36'
     annotationProcessor 'org.projectlombok:lombok:1.18.36'

--- a/slack-service/src/main/resources/application-dev.yml
+++ b/slack-service/src/main/resources/application-dev.yml
@@ -36,3 +36,9 @@ slack:
     token: ${SLACK_TOKEN}
   admin:
       id: C08NM9CQ3SA
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: 'prometheus'

--- a/slack-service/src/main/resources/application-performance.yml
+++ b/slack-service/src/main/resources/application-performance.yml
@@ -29,3 +29,9 @@ server:
 slack:
   admin:
     id: C08NM9CQ3SA
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: 'prometheus'

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -58,6 +58,10 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    // prometheus
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
     implementation "org.springframework.boot:spring-boot-starter-security"
 

--- a/user-service/src/main/resources/application-dev.yml
+++ b/user-service/src/main/resources/application-dev.yml
@@ -32,3 +32,9 @@ eureka:
 
 server:
   port: 8001
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: 'prometheus'


### PR DESCRIPTION
### 변경 타입
* [ ] 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
아래를 따라서 설정해주세요!
각 서비스에 의존성을 추가해주세요
```
// actuator
implementation 'org.springframework.boot:spring-boot-starter-actuator'

// prometheus
runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
```
yml 파일에 아래를 추가해서 메트릭 수집하도록 합니다
```
management:
  endpoints:
    web:
      exposure:
        include: 'prometheus'
```
설정 후에
localhost:서비스포트번호/actuator
localhost:서비스포트번호/actuator/prometheus
엔드포인트를 검색해보시고 다음과 같은 response가 나오는지 확인해주세요
<img width="1128" alt="스크린샷 2025-04-25 오후 8 14 12" src="https://github.com/user-attachments/assets/00cbd096-7931-4533-a1fa-1448fb16442a" />
<img width="1128" alt="스크린샷 2025-04-25 오후 8 15 30" src="https://github.com/user-attachments/assets/41e5869d-b358-4052-80d2-103ae0ad5866" />
docker-compose에 prometheus랑 grafana 설정했습니다! 도커 다시 업 해주세요!
localhost:9090으로 들어가면 prometheus 연결됩니다!
localhost:9090/targets로 들어가면 각 서비스가 설정된 것을 확인할 수 있습니다!
![스크린샷 2025-04-27 오전 2 41 44](https://github.com/user-attachments/assets/00101b60-7b90-4990-b2a6-0857b0518e6d)
status가 up이면 잘된겁니다!
localhost:3000으로 접속하고 로그인을 합니다
id: admin
pw: admin
![스크린샷 2025-04-27 오전 2 25 34](https://github.com/user-attachments/assets/0e7badfe-97cd-4332-8c40-ac8d22cbe60a)
각 서비스 대시보드를 볼 수 있습니다.
![스크린샷 2025-04-27 오전 2 12 30](https://github.com/user-attachments/assets/0412ae8e-be21-404c-a627-8f3d759976aa)
각 서비스 CPU 50% 이상 사용 시 슬랙 알람이 오게 설정했습니다.
확인해보시고 안되면 말씀해주세요

### 테스트 결과
![스크린샷 2025-04-27 오전 1 54 53](https://github.com/user-attachments/assets/c2df19b7-f92c-449d-8c51-e2c36e3cc37e)

