### PR TITLE
⚙ setting [#285-gateway] Resilience4J 설정

### DIFF
--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     // prometheus
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+    //Resilience4J
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
 }
 
 ext {

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -52,7 +52,10 @@ spring:
           enabled: true
       loadbalancer:
         enabled: true
-
+      default-filters:
+        - name: CircuitBreaker
+          args:
+            name: defaultCircuitBreaker
 
 springdoc:
   swagger-ui:
@@ -81,4 +84,29 @@ management:
   endpoints:
     web:
       exposure:
-        include: 'prometheus'
+        include:
+          - 'prometheus'
+          - 'circuitbreakers'
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        registerHealthIndicator: true
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 10
+        # 최소 5개의 요청이 있어야 서킷이 계산
+        minimumNumberOfCalls: 5
+        slowCallRateThreshold: 100
+        # 요청이 느린 것으로 간주되는 기간
+        slowCallDurationThreshold: 60000
+        failureRateThreshold: 60
+        # 서킷이 HALF_OPEN상태일 때 허용되는 호출수
+        permittedNumberOfCallsInHalfOpenState: 3
+        # 서킷의 상태가 OPEN에서 HALF_OPEN으로 변경되기 전에 Circuit Break가 기다리는 시간
+        waitDurationInOpenState: 60s
+        automatic-transition-from-open-to-half-open-enabled: true
+    instances:
+      defaultCircuitBreaker: # circuitbreaker name
+        baseConfig: default # 기본 config 지정
+        slowCallDurationThreshold: 3000


### PR DESCRIPTION
### 변경 타입
* [ ] 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
localhost:8080/actuator/circuitbreakers 요청을 하면 등록된 서킷브레이커를 확인할 수 있습니다.
![스크린샷 2025-04-28 오전 11 01 19](https://github.com/user-attachments/assets/195ab519-a582-4d1a-abc1-6fbdeea00915)
처음에는 CLOSED 상태입니다.
오류를 많이 발생해보겠습니다.
user service를 실행시키지 않은 상태에서 login 요청을 마구 보냈습니다
![스크린샷 2025-04-28 오전 11 04 13](https://github.com/user-attachments/assets/460c95b8-f682-4e28-9b1e-f5291c5b74dc)
로그를 보면 어느 순간부터는 No servers available for service: user-service 경고가 발생하지 않습니다.
![스크린샷 2025-04-28 오전 11 01 53](https://github.com/user-attachments/assets/9b8824d2-eee5-4f1b-8e46-688442f26bf7)
총 9건을 요청했는데 초반 5건이 실패되었고 그 후 요청된 4건이 차단됐습니다. 현재 서킷 상태는 OPEN으로 변경되었습니다.
일정 시간이 지나면 HALF_OPEN 상태로 변경됩니다.
![스크린샷 2025-04-28 오전 11 03 36](https://github.com/user-attachments/assets/52890130-dae1-472b-bf79-86d57dcd03c8)
이 상태에서는 요청을 몇 개 보내서 진짜 서버가 정상인지 확인해보는 상태입니다.
요청들이 성공하면 CLOSED 상태로 복귀하고 실패한다면 다시 OPEN으로 가서 차단됩니다.

![스크린샷 2025-04-28 오전 11 07 59](https://github.com/user-attachments/assets/c807c771-4c77-41b5-a49c-d5a7d9c87d6c)
Grafana 대시보드에서도 확인할 수 있습니다!
### 테스트 결과

