### PR TITLE
✨ feat [#310-product-restore-redis] 상품 재고 복구 레디스 분산락 적용 및 무제한 복구 처리 불가하도록 예외로직 추가

### DIFF
--- a/product-service/src/main/java/com/business/productservice/application/exception/ProductExceptionCode.java
+++ b/product-service/src/main/java/com/business/productservice/application/exception/ProductExceptionCode.java
@@ -11,8 +11,9 @@ public enum ProductExceptionCode implements ExceptionCode {
     PRODUCT_NOT_FOUND("P101", "해당 상품은 없는 정보입니다.", HttpStatus.NOT_FOUND),
     PRODUCT_STOCK_SOLDOUT("P102","해당 상품은 매진되었습니다.", HttpStatus.BAD_REQUEST),
     LOCK_FAILED("P103", "요청이 몰려 처리에 실패했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
-    LOCK_INTERRUPTED("P103", "처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
-    ;;
+    LOCK_INTERRUPTED("P103", "처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    PRODUCT_STOCK_RESTORE_LIMIT_EXCEEDED("P104","복구 수량을 초과했습니다.", HttpStatus.BAD_REQUEST)
+    ;
 
     private final String code;
     private final String message;

--- a/product-service/src/main/java/com/business/productservice/domain/product/entity/StockEntity.java
+++ b/product-service/src/main/java/com/business/productservice/domain/product/entity/StockEntity.java
@@ -1,11 +1,14 @@
 package com.business.productservice.domain.product.entity;
 
+import com.business.productservice.application.exception.ProductExceptionCode;
 import com.business.productservice.domain.product.vo.ProductType;
+import com.github.themepark.common.application.exception.CustomException;
 import com.github.themepark.common.domain.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.UUID;
 
@@ -14,6 +17,7 @@ import java.util.UUID;
 @Table(name = "p_product_stocks")
 @AllArgsConstructor
 @NoArgsConstructor
+@Slf4j
 public class StockEntity extends BaseEntity {
 
     @Id
@@ -53,6 +57,11 @@ public class StockEntity extends BaseEntity {
     public void restore(){
         if(!product.getProductType().equals(ProductType.EVENT)){
             return;
+        }
+        if (this.stock >= product.getLimitQuantity()) {
+            log.error("재고 복구 수량 초과 요청- productId: {}, 현재 재고: {}, 제한 수량: {}",
+                    product.getId(), this.stock, product.getLimitQuantity());
+            throw new CustomException(ProductExceptionCode.PRODUCT_STOCK_RESTORE_LIMIT_EXCEEDED);
         }
         this.stock++;
     }


### PR DESCRIPTION
### 변경 타입
* [x] 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
- 분산락 적용 및 재고 복구된 value를 레디스에 캐싱
- 무제한 복구 불가능하도록 엔티티 내부에서 처리
- 해당 요청이 온다면 로그를 남겨 확인
- 레디스 ttl 설정 : 5분 (실시간 정확한 재고 확인이 핵심이기 때문에 TTL을 너무 길게 주면 안 되고, 추천 TTL은 '3~5분' 정도가 가장 안전하면서 Redis 자원도 절약할 수 있다고 합니다)

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
