### PR TITLE
✨ feat [#318-product-kafka] 카프카 실패  시 DLQ 처리 로직 추가 및 수동 Ack 설정 / zipkin 의존성 추가

### DIFF
--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -88,6 +88,10 @@ dependencies {
     // prometheus
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
+    //zipkin
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+
 }
 
 // 컴파일 시 빌드 폴더를 지웁니다.

--- a/product-service/src/main/java/com/business/productservice/infrastructure/kafka/ProductKafkaConsumer.java
+++ b/product-service/src/main/java/com/business/productservice/infrastructure/kafka/ProductKafkaConsumer.java
@@ -3,6 +3,7 @@ package com.business.productservice.infrastructure.kafka;
 import com.business.productservice.application.service.v3.ProductServiceApiV3;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -14,14 +15,33 @@ public class ProductKafkaConsumer {
     private final ProductServiceApiV3 productService;
 
     @KafkaListener(topics = "stock-decrease-topic", groupId = "product-service-group")
-    public void consumeStockDecrease(String productId){
-        UUID id = UUID.fromString(productId);
-        productService.postDecreaseById(id);
+    public void consumeStockDecrease(String productId, Acknowledgment ack){
+        try {
+            UUID id = UUID.fromString(productId);
+            // 의도적으로 에러 발생
+//            if (true) {
+//                throw new RuntimeException("강제로 에러 발생 (DLQ 테스트)");
+//            }
+            productService.postDecreaseById(id);
+
+            ack.acknowledge(); //성공 > ack 호출
+
+        } catch (Exception e) {
+            // 실패하면 ack 호출 안 함 > Spring Kafka가 재시도, DLQ 이동
+            throw e;
+        }
     }
 
     @KafkaListener(topics = "stock-restore-topic", groupId = "product-service-group")
-    public void consumeStockRestore(String productId){
-        UUID id = UUID.fromString(productId);
-        productService.postRestoreById(id);
+    public void consumeStockRestore(String productId, Acknowledgment ack){
+        try {
+            UUID id = UUID.fromString(productId);
+            productService.postRestoreById(id);
+
+            ack.acknowledge();
+
+        } catch (Exception e) {
+            throw e;
+        }
     }
 }

--- a/product-service/src/main/java/com/business/productservice/infrastructure/kafka/TestKafkaProducer.java
+++ b/product-service/src/main/java/com/business/productservice/infrastructure/kafka/TestKafkaProducer.java
@@ -1,0 +1,21 @@
+package com.business.productservice.infrastructure.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+/*
+* 테스트 용 프로듀서 파일
+* */
+@RequiredArgsConstructor
+@Service
+public class TestKafkaProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public void sendStockDecreaseTest(UUID productId) {
+        kafkaTemplate.send("stock-decrease-topic", productId.toString());
+    }
+}

--- a/product-service/src/main/java/com/business/productservice/presentation/controller/v3/ProductControllerApiV3.java
+++ b/product-service/src/main/java/com/business/productservice/presentation/controller/v3/ProductControllerApiV3.java
@@ -5,6 +5,7 @@ import com.business.productservice.application.dto.v3.request.ReqProductPutDTOAp
 import com.business.productservice.application.dto.v3.response.*;
 import com.business.productservice.application.service.v3.ProductServiceApiV3;
 import com.business.productservice.domain.product.entity.ProductEntity;
+import com.business.productservice.infrastructure.kafka.TestKafkaProducer;
 import com.github.themepark.common.application.aop.annotation.ApiPermission;
 import com.github.themepark.common.application.dto.ResDTO;
 import com.querydsl.core.types.Predicate;
@@ -27,6 +28,7 @@ import java.util.UUID;
 public class ProductControllerApiV3 {
 
         private final ProductServiceApiV3 productServiceApiV3;
+        private final TestKafkaProducer testKafkaProducer;
 
         @ApiPermission(roles = {ApiPermission.Role.MASTER, ApiPermission.Role.MANAGER})
         @PostMapping
@@ -151,5 +153,12 @@ public class ProductControllerApiV3 {
                                 .build(),
                         HttpStatus.OK
                 );
+        }
+
+        //카프카 테스트 용 (삭제 예정)
+        @PostMapping("/send-stock-decrease")
+        public String sendStockDecrease(@RequestParam("productId") UUID productId) {
+                testKafkaProducer.sendStockDecreaseTest(productId);
+                return "Stock decrease test message sent!";
         }
 }

--- a/product-service/src/main/resources/application-dev.yml
+++ b/product-service/src/main/resources/application-dev.yml
@@ -43,6 +43,12 @@ management:
     web:
       exposure:
         include: 'prometheus'
+  tracing:
+    sampling:
+      probability: 1.0
+    enabled: true
+    zipkin:
+      endpoint: http://localhost:9411/api/v2/spans
 
 server:
   port: 8004

--- a/product-service/src/test/java/com/business/productservice/product/presentation/controller/v1/ProductControllerApiV1Test.java
+++ b/product-service/src/test/java/com/business/productservice/product/presentation/controller/v1/ProductControllerApiV1Test.java
@@ -1,11 +1,9 @@
-package com.business.productservice.product.presentation.controller;
+package com.business.productservice.product.presentation.controller.v1;
 
 import com.business.productservice.application.dto.v1.request.ReqProductPostDTOApiV1;
 import com.business.productservice.application.dto.v1.request.ReqProductPutDTOApiV1;
 import com.business.productservice.application.dto.v1.request.ReqStockDecreasePostDTOApiV1;
 import com.business.productservice.application.dto.v1.request.ReqStockRestorePostDTOApiV1;
-import com.business.productservice.application.dto.v1.response.ResProductGetByIdDTOApiV1;
-import com.business.productservice.application.service.v1.ProductServiceApiV1;
 import com.business.productservice.domain.product.vo.ProductStatus;
 import com.business.productservice.domain.product.vo.ProductType;
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
@@ -17,7 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.context.ActiveProfiles;
@@ -30,7 +27,6 @@ import java.util.UUID;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 
 @SpringBootTest
@@ -45,10 +41,6 @@ public class ProductControllerApiV1Test {
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @SuppressWarnings("removal")
-    @MockBean
-    private ProductServiceApiV1 productService;
 
     @Test
     public void testProductPostSuccess() throws Exception {
@@ -89,28 +81,8 @@ public class ProductControllerApiV1Test {
 
     @Test
     public void testProductGetByIdSuccess() throws Exception {
-        UUID testId = UUID.randomUUID();
-
-        ResProductGetByIdDTOApiV1 responseDto = ResProductGetByIdDTOApiV1.builder()
-                .product(
-                        ResProductGetByIdDTOApiV1.Product.builder()
-                                .name("테스트 상품")
-                                .description("테스트 설명")
-                                .productType(ProductType.EVENT)
-                                .price(15000)
-                                .limitQuantity(30)
-                                .eventStartAt(LocalDateTime.now())
-                                .eventEndAt(LocalDateTime.now().plusDays(7))
-                                .productStatus(ProductStatus.DRAFT)
-                                .build()
-                )
-                .build();
-
-        // Mocking: 해당 ID로 호출 시 응답 DTO 리턴
-        when(productService.getBy(testId)).thenReturn(responseDto);
-
         mockMvc.perform(
-                        RestDocumentationRequestBuilders.get("/v1/products/{id}", testId)
+                        RestDocumentationRequestBuilders.get("/v1/products/{id}", "476c2d9e-cb99-49a3-9fb8-721096683d04")
                 )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isOk()
@@ -282,6 +254,32 @@ public class ProductControllerApiV1Test {
                                 )
                         );
 
+    }
+
+    @Test
+    public void testStockGetByIdSuccess() throws Exception {
+
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/v1/products/{id}/stock", "476c2d9e-cb99-49a3-9fb8-721096683d04")
+                                .header("X-User-Role","MASTER")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpectAll(
+                        MockMvcResultMatchers.status().isOk()
+                )
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("상품재고 개별 조회 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Product v1")
+                                        .pathParameters(
+                                                parameterWithName("id").type(SimpleType.STRING).description("상품 ID")
+                                        )
+                                        .build()
+                                )
+                        )
+                );
     }
 
     private String dtoToJson(Object dto) throws Exception {

--- a/product-service/src/test/java/com/business/productservice/product/presentation/controller/v3/ProductControllerApiV3Test.java
+++ b/product-service/src/test/java/com/business/productservice/product/presentation/controller/v3/ProductControllerApiV3Test.java
@@ -1,0 +1,291 @@
+package com.business.productservice.product.presentation.controller.v3;
+
+import com.business.productservice.application.dto.v3.request.ReqProductPostDTOApiV3;
+import com.business.productservice.application.dto.v3.request.ReqProductPutDTOApiV3;
+import com.business.productservice.application.dto.v3.request.ReqStockDecreasePostDTOApiV3;
+import com.business.productservice.application.dto.v3.request.ReqStockRestorePostDTOApiV3;
+import com.business.productservice.domain.product.vo.ProductStatus;
+import com.business.productservice.domain.product.vo.ProductType;
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+
+@SpringBootTest
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("dev")
+public class ProductControllerApiV3Test {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void testProductPostSuccess() throws Exception {
+        ReqProductPostDTOApiV3 dto = ReqProductPostDTOApiV3.builder()
+                .product(
+                        ReqProductPostDTOApiV3.Product.builder()
+                                .name("20% 할인권")
+                                .description("할인권 설명입니다.")
+                                .productType(ProductType.EVENT)
+                                .price(30000)
+                                .limitQuantity(100)
+                                .eventStartAt(LocalDateTime.now())
+                                .eventEndAt(LocalDateTime.now().plusDays(1))
+                                .build()
+                )
+                .build();
+
+        mockMvc.perform(
+                RestDocumentationRequestBuilders.post("/v3/products")
+                        .header("X-User-Role","MASTER")
+                        .content(dtoToJson(dto))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpectAll(
+                        MockMvcResultMatchers.status().isCreated()
+                )
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("상품 생성 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Product v3")
+                                        .build()
+                                )
+                        )
+                );
+    }
+
+    @Test
+    public void testProductGetByIdSuccess() throws Exception {
+
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/v3/products/{id}", "476c2d9e-cb99-49a3-9fb8-721096683d04")
+                )
+                .andExpectAll(
+                        MockMvcResultMatchers.status().isOk()
+                )
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("상품 개별 조회 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Product v3")
+                                        .pathParameters(
+                                                parameterWithName("id").type(SimpleType.STRING).description("상품 ID")
+                                        )
+                                        .build()
+                                )
+                        )
+                );
+    }
+
+    @Test
+    public void testProductGetSuccess() throws Exception {
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/v3/products")
+                )
+                .andExpectAll(
+                        MockMvcResultMatchers.status().isOk()
+                )
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("상품 전체 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Product v3")
+                                        .build()
+                                )
+                        )
+                );
+    }
+
+    @Test
+    public void testProductPutByIdSuccess() throws Exception {
+        ReqProductPutDTOApiV3 dto = ReqProductPutDTOApiV3.builder()
+                .product(
+                        ReqProductPutDTOApiV3.Product.builder()
+                                .name("상품 이름")
+                                .description("상품 설명")
+                                .productType(ProductType.EVENT)
+                                .price(35000)
+                                .limitQuantity(100)
+                                .eventStartAt(LocalDateTime.now())
+                                .eventEndAt(LocalDateTime.now().plusDays(1))
+                                .productStatus(ProductStatus.CLOSED)
+                                .build()
+                )
+                .build();
+
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.put("/v3/products/{id}",UUID.randomUUID())
+                        .content(dtoToJson(dto))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpectAll(
+                        MockMvcResultMatchers.status().isOk()
+                )
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("상품 수정 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Product v3")
+                                        .pathParameters(
+                                                parameterWithName("id").type(SimpleType.STRING).description("상품 ID")
+                                        )
+                                        .build()
+                                )
+                        )
+                );
+
+    }
+
+    @Test
+    public void testProductDeleteSuccess() throws Exception {
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.delete("/v3/products/{id}", UUID.randomUUID())
+                                .header("X-User-Role","MASTER")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpectAll(
+                        MockMvcResultMatchers.status().isOk()
+                )
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("상품 삭제 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Product v3")
+                                        .pathParameters(
+                                                parameterWithName("id").type(SimpleType.STRING).description("상품 ID")
+                                        )
+                                        .build()
+                                )
+                        )
+                );
+    }
+
+    @Test
+    public void testStockDecreasePostSuccess() throws Exception {
+
+        ReqStockDecreasePostDTOApiV3 dto = ReqStockDecreasePostDTOApiV3.builder()
+                .stock(
+                        ReqStockDecreasePostDTOApiV3.Stock.builder()
+                                .stockDecreaseAmount(3)
+                                .build()
+                )
+                .build();
+
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.post("/v3/products/internal/{id}/stocks-decrease", UUID.randomUUID())
+                                .header("X-User-Role","MASTER")
+                                .content(dtoToJson(dto))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpectAll(
+                        MockMvcResultMatchers.status().isOk()
+                )
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("상품 재고 차감 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Product v3")
+                                        .pathParameters(
+                                                parameterWithName("id").type(SimpleType.STRING).description("상품 ID")
+                                        )
+                                        .build()
+                                )
+                        )
+                );
+    }
+
+    @Test
+    public void testStockRestorePostSuccess() throws Exception {
+
+        ReqStockRestorePostDTOApiV3 dto = ReqStockRestorePostDTOApiV3.builder()
+                .stock(
+                        ReqStockRestorePostDTOApiV3.Stock.builder()
+                                .stockRestoreAmount(3)
+                                .build()
+                )
+                .build();
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.post("/v3/products/internal/{id}/stocks-restore", UUID.randomUUID())
+                                .header("X-User-Role","MASTER")
+                                .content(dtoToJson(dto))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                        .andExpectAll(
+                                MockMvcResultMatchers.status().isOk()
+                        )
+                        .andDo(
+                                MockMvcRestDocumentationWrapper.document("상품 재고 복구 성공",
+                                        preprocessRequest(prettyPrint()),
+                                        preprocessResponse(prettyPrint()),
+                                        resource(ResourceSnippetParameters.builder()
+                                                .tag("Product v3")
+                                                .pathParameters(
+                                                        parameterWithName("id").type(SimpleType.STRING).description("상품 ID")
+                                                )
+                                                .build()
+                                        )
+                                )
+                        );
+
+    }
+
+    @Test
+    public void testStockGetByIdSuccess() throws Exception {
+
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/v3/products/{id}/stock", "476c2d9e-cb99-49a3-9fb8-721096683d04")
+                                .header("X-User-Role","MASTER")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpectAll(
+                        MockMvcResultMatchers.status().isOk()
+                )
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("상품재고 개별 조회 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(ResourceSnippetParameters.builder()
+                                        .tag("Product v3")
+                                        .pathParameters(
+                                                parameterWithName("id").type(SimpleType.STRING).description("상품 ID")
+                                        )
+                                        .build()
+                                )
+                        )
+                );
+    }
+
+    private String dtoToJson(Object dto) throws Exception {
+        return objectMapper.writeValueAsString(dto);
+    }
+}

--- a/product-service/src/test/resources/httpclient/productV3.http
+++ b/product-service/src/test/resources/httpclient/productV3.http
@@ -51,7 +51,6 @@ Content-Type: application/json
 
 ### 4. 상품 단건 조회
 GET http://localhost:8080/v3/products/e61caf66-b5c0-4e23-bb9f-fd75821efc67
-Authorization: {{accessToken}}
 Content-Type: application/json
 
 ### 5. 상품 정보 수정
@@ -95,5 +94,10 @@ Content-Type: application/json
 
 ### 10. 상품 재고 조회
 GET http://localhost:8080/v3/products/e61caf66-b5c0-4e23-bb9f-fd75821efc67/stock
+Authorization: {{accessToken}}
+Content-Type: application/json
+
+### 11. 카프카 테스트 엔드포인트 호출
+POST http://localhost:8080/v3/products/send-stock-decrease?productId=e61caf66-b5c0-4e23-bb9f-fd75821efc67
 Authorization: {{accessToken}}
 Content-Type: application/json


### PR DESCRIPTION
### 변경 타입
* [x] 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
- DeadLetterPublishingRecoverer로 DLQ 설정
- FixedBackOff을 이용한 재시도 로직 적용 (1초 간격, 최대 3회)
- MANUAL_IMMEDIATE Ack 모드 설정

- 수동 Ack 모드 적용 (acknowledge 호출로 명시적 커밋 처리)
- DLQ 테스트를 위한 강제 예외 발생 코드 주석 처리
- 예외 발생 시 ack 생략 → Spring Kafka가 재시도 및 DLQ 이동 처리 가능

## Kafka DLQ 및 수동 ACK 도입

### 변경 내용
- Kafka Consumer 수동 ACK 설정
- 메시지 처리 실패 시 재시도 + DLQ 분기 처리

### 도입 배경
- 기존 메시지 처리 실패 시 유실 우려 존재
- 장애 대응을 위한 메시지 격리 및 추적이 어려움
- 운영 중 오류 메시지 식별 및 재처리 필요

### 기대 효과
- 메시지 유실 방지
- 장애 발생 시 DLQ를 통해 신속한 파악 및 재처리 가능
- Kafka 기반 시스템의 안정성 및 가시성 향상

### 테스트 결과
![image.png](attachment:a119f5c8-5b10-4c65-b207-a4e3d27f48e5:image.png)
![image.png](attachment:42d7a69b-2350-42ff-b027-0997d9e5dad0:image.png)
