### PR TITLE
🐛 bug [#337-gateway] TimeLimiter 기본 timeoutDuration을 6초로 연장

### DIFF
--- a/gateway-service/src/main/resources/application-prod.yml
+++ b/gateway-service/src/main/resources/application-prod.yml
@@ -111,3 +111,13 @@ resilience4j:
       defaultCircuitBreaker: # circuitbreaker name
         baseConfig: default # 기본 config 지정
         slowCallDurationThreshold: 3000
+  timelimiter:
+    configs:
+      default:
+        timeoutDuration: 6s  # 6초로 늘림
+        cancelRunningFuture: true
+
+#logging:
+#  level:
+#    org.springframework.cloud.gateway: DEBUG
+#    reactor.netty.http.client: DEBUG


### PR DESCRIPTION
### 변경 타입
* [ ] 기능 추가/수정
* [x] 버그 수정
* [ ] 리팩토링
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
* [ ] 문서작성

## 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

### 변경 사항/추가설명
TimeLimiter 기본 timeoutDuration을 6초로 연장

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
